### PR TITLE
Fix/legend style switch

### DIFF
--- a/.changeset/ten-dolls-tease.md
+++ b/.changeset/ten-dolls-tease.md
@@ -1,0 +1,5 @@
+---
+"@watergis/svelte-maplibre-legend": patch
+---
+
+[breaking change] deleted `style` parameter to be exported in order to fix the bug of style editor after switching to different style

--- a/.changeset/ten-dolls-tease.md
+++ b/.changeset/ten-dolls-tease.md
@@ -2,4 +2,11 @@
 "@watergis/svelte-maplibre-legend": patch
 ---
 
-[breaking change] deleted `style` parameter to be exported in order to fix the bug of style editor after switching to different style
+- [breaking change] deleted `style` parameter to be exported in order to fix the bug of style editor after switching to different style
+- [breaking change] watch `style:change` custom event of maplibre map object to recreate legend panel.
+
+When you changed map style.json, please fire `style:change` event like the following source code.
+
+```
+map.on('style:change')
+```

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -42,6 +42,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.46.1",
 		"@typescript-eslint/parser": "^5.46.1",
 		"@watergis/svelte-maplibre-menu": "workspace:^0.1.17",
+		"@watergis/svelte-maplibre-style-switcher": "workspace:^0.1.15",
 		"bulma": "^0.9.4",
 		"bulma-switch": "^2.0.4",
 		"eslint": "^8.29.0",

--- a/packages/legend/src/example/Map.svelte
+++ b/packages/legend/src/example/Map.svelte
@@ -3,7 +3,6 @@
 	import { Map } from 'maplibre-gl';
 	import { MenuControl } from '@watergis/svelte-maplibre-menu';
 	import { LegendPanel, LegendHeader } from '$lib';
-	import type { StyleSpecification } from 'maplibre-gl';
 	import {
 		StyleSwitcher,
 		StyleUrl,
@@ -14,7 +13,6 @@
 	let map: Map;
 
 	let isMenuShown = true;
-	let style: StyleSpecification;
 
 	let styles = [
 		{
@@ -87,15 +85,11 @@
 			style: selectedStyle.uri,
 			hash: true
 		});
-
-		map.on('load', () => {
-			style = map.getStyle();
-		});
 	});
 
 	const onStyleChange = () => {
 		if (!map) return;
-		style = map.getStyle();
+		map.fire('style:change');
 	};
 </script>
 

--- a/packages/legend/src/example/Map.svelte
+++ b/packages/legend/src/example/Map.svelte
@@ -115,7 +115,6 @@
 		<div class="legend-content">
 			<LegendPanel
 				bind:map
-				bind:style
 				bind:onlyRendered
 				bind:onlyRelative
 				bind:enableLayerOrder

--- a/packages/legend/src/example/Map.svelte
+++ b/packages/legend/src/example/Map.svelte
@@ -4,19 +4,43 @@
 	import { MenuControl } from '@watergis/svelte-maplibre-menu';
 	import { LegendPanel, LegendHeader } from '$lib';
 	import type { StyleSpecification } from 'maplibre-gl';
+	import {
+		StyleSwitcher,
+		StyleUrl,
+		type StyleSwitcherOption
+	} from '@watergis/svelte-maplibre-style-switcher';
 
 	let mapContainer: HTMLDivElement;
 	let map: Map;
 
 	let isMenuShown = true;
 	let style: StyleSpecification;
-	$: {
-		if (map) {
-			map.on('load', () => {
-				style = map.getStyle();
-			});
+
+	let styles = [
+		{
+			title: 'UNVT Water (OSM)',
+			uri: `https://narwassco.github.io/mapbox-stylefiles/unvt/style.json`
+		},
+		{
+			title: 'UNVT Water (Building)',
+			uri: `https://narwassco.github.io/mapbox-stylefiles/unvt/style-buildings.json`
+		},
+		{
+			title: 'Satellite Water',
+			uri: `https://narwassco.github.io/mapbox-stylefiles/unvt/style-aerial.json`
+		},
+		{
+			title: 'UNVT Sewer',
+			uri: `https://narwassco.github.io/mapbox-stylefiles/unvt/style-sewer.json`
+		},
+		{
+			title: 'Satellite Sewer',
+			uri: `https://narwassco.github.io/mapbox-stylefiles/unvt/style-aerial-sewer.json`
 		}
-	}
+	];
+
+	const styleUrlObj = new StyleUrl();
+	let selectedStyle: StyleSwitcherOption = styleUrlObj.getInitialStyle(styles);
 
 	let onlyRendered = true;
 	let onlyRelative = true;
@@ -60,14 +84,26 @@
 			container: mapContainer,
 			// style: 'https://undp-data.github.io/style/style.json'
 			// style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style-aerial.json'
-			style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
+			style: selectedStyle.uri,
 			hash: true
 		});
+
+		map.on('load', () => {
+			style = map.getStyle();
+		});
 	});
+
+	const onStyleChange = () => {
+		if (!map) return;
+		style = map.getStyle();
+	};
 </script>
 
 <MenuControl bind:map position={'top-right'} bind:isMenuShown>
 	<div slot="primary" class="primary-container">
+		<div class="style-header">
+			<StyleSwitcher bind:map bind:selectedStyle bind:styles on:change={onStyleChange} />
+		</div>
 		<div class="legend-header">
 			<LegendHeader
 				bind:onlyRendered
@@ -79,7 +115,7 @@
 		<div class="legend-content">
 			<LegendPanel
 				bind:map
-				{style}
+				bind:style
 				bind:onlyRendered
 				bind:onlyRelative
 				bind:enableLayerOrder
@@ -106,12 +142,17 @@
 		z-index: 1;
 	}
 
-	$height: calc(100vh - 56px);
+	$height: calc(100vh - 140px);
 
 	.primary-container {
 		display: flex;
 		flex-direction: column;
 		position: relative;
+
+		.style-header {
+			width: 100%;
+			margin-bottom: 0.5rem;
+		}
 
 		.legend-header {
 			padding-left: 0.5rem;

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -27,6 +27,7 @@
 			map.on('load', () => {
 				style = map.getStyle();
 			});
+			map.on('style:change', handleStyleChanged);
 		}
 
 		if (relativeLayers && Object.keys(relativeLayers).length === 0) {
@@ -43,11 +44,15 @@
 		if (!style) return;
 		const styleUrl = style.sprite;
 		if (!styleUrl) return;
-		if (isLoadSprite === true) {
-			spriteLoader = new SpriteLoader(styleUrl);
-			spriteLoader.load().then(updateLayers);
+		if (map.isStyleLoaded()) {
+			if (isLoadSprite === true) {
+				spriteLoader = new SpriteLoader(styleUrl);
+				spriteLoader.load().then(updateLayers);
+			} else {
+				updateLayers();
+			}
 		} else {
-			updateLayers();
+			setTimeout(handleStyleChanged, 500);
 		}
 	};
 

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -6,12 +6,12 @@
 	import { distinct } from './util/distinct';
 
 	export let map: Map;
-	export let style: StyleSpecification;
 	export let onlyRendered = true;
 	export let onlyRelative = true;
 	export let enableLayerOrder = false;
 	export let disableVisibleButton = false;
 	export let enableEditing = true;
+	let style: StyleSpecification;
 	let spriteLoader: SpriteLoader | undefined;
 	let hovering: boolean | number | undefined = false;
 	$: isShowLastDropArea = hovering === getLastVisibleIndex();
@@ -24,9 +24,8 @@
 		if (map) {
 			map.on('moveend', updateLayers);
 			map.on('styledata', updateLayers);
-			map.on('load', updateLayers);
-			map.on('style:changed', () => {
-				handleStyleChanged(false);
+			map.on('load', () => {
+				style = map.getStyle();
 			});
 		}
 

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -174,99 +174,35 @@
 		}
 		return isRelative;
 	};
+
+	const showOnList = (layerId: string) => {
+		let isShow = false;
+		if (onlyRendered === true) {
+			if (visibleLayerMap[layerId]) {
+				if (onlyRelative === true) {
+					if (isRelativeLayer(layerId)) {
+						isShow = true;
+					}
+				} else {
+					isShow = true;
+				}
+			}
+		} else if (onlyRelative === true) {
+			if (isRelativeLayer(layerId)) {
+				isShow = true;
+			}
+		} else {
+			isShow = true;
+		}
+		return isShow;
+	};
 </script>
 
 <ul class="legend-panel">
 	{#if spriteLoader}
 		{#key style}
 			{#each allLayers as layer, index (layer.id)}
-				{#if onlyRendered === true}
-					{#if visibleLayerMap[layer.id]}
-						{#if onlyRelative === true}
-							{#if isRelativeLayer(layer.id)}
-								<div
-									class="list-item"
-									draggable={enableLayerOrder}
-									on:dragstart={(event) => dragstart(event, index)}
-									on:drop|preventDefault={(event) => drop(event, index, layer)}
-									on:dragover={(event) => dragover(event)}
-									on:dragenter={() => {
-										hovering = index;
-									}}
-									class:is-active={hovering === index}
-								>
-									<li class="legend-panel-block">
-										<Layer
-											{map}
-											{layer}
-											{spriteLoader}
-											{relativeLayers}
-											bind:enableLayerOrder
-											bind:disableVisibleButton
-											bind:enableEditing
-											on:visibilityChanged={layerVisibilityChanged}
-											on:layerOrderChanged={layerOrderChanged}
-										/>
-									</li>
-								</div>
-							{/if}
-						{:else}
-							<div
-								class="list-item"
-								draggable={enableLayerOrder}
-								on:dragstart={(event) => dragstart(event, index)}
-								on:drop|preventDefault={(event) => drop(event, index, layer)}
-								on:dragover={(event) => dragover(event)}
-								on:dragenter={() => {
-									hovering = index;
-								}}
-								class:is-active={hovering === index}
-							>
-								<li class="legend-panel-block">
-									<Layer
-										{map}
-										{layer}
-										{spriteLoader}
-										{relativeLayers}
-										bind:enableLayerOrder
-										bind:disableVisibleButton
-										bind:enableEditing
-										on:visibilityChanged={layerVisibilityChanged}
-										on:layerOrderChanged={layerOrderChanged}
-									/>
-								</li>
-							</div>
-						{/if}
-					{/if}
-				{:else if onlyRelative === true}
-					{#if isRelativeLayer(layer.id)}
-						<div
-							class="list-item"
-							draggable={enableLayerOrder}
-							on:dragstart={(event) => dragstart(event, index)}
-							on:drop|preventDefault={(event) => drop(event, index, layer)}
-							on:dragover={(event) => dragover(event)}
-							on:dragenter={() => {
-								hovering = index;
-							}}
-							class:is-active={hovering === index}
-						>
-							<li class="legend-panel-block">
-								<Layer
-									{map}
-									{layer}
-									{spriteLoader}
-									{relativeLayers}
-									bind:enableLayerOrder
-									bind:disableVisibleButton
-									bind:enableEditing
-									on:visibilityChanged={layerVisibilityChanged}
-									on:layerOrderChanged={layerOrderChanged}
-								/>
-							</li>
-						</div>
-					{/if}
-				{:else}
+				{#if showOnList(layer.id)}
 					<div
 						class="list-item"
 						draggable={enableLayerOrder}

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
@@ -60,14 +60,11 @@
 		heatmapLayer.maxzoom = symbolLayer.maxzoom ?? 24;
 
 		map.addLayer(heatmapLayer, symbolLayer.id);
-		map.fire('style:changed');
 	};
 
 	const deleteHeatmap = () => {
 		if (map.getLayer(heatmapLayerId)) {
 			map.removeLayer(heatmapLayerId);
-
-			map.fire('style:changed');
 		}
 	};
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,7 @@ importers:
       '@typescript-eslint/parser': ^5.46.1
       '@watergis/legend-symbol': ^0.2.3
       '@watergis/svelte-maplibre-menu': workspace:^0.1.17
+      '@watergis/svelte-maplibre-style-switcher': workspace:^0.1.15
       bulma: ^0.9.4
       bulma-switch: ^2.0.4
       chroma-js: ^2.4.2
@@ -256,6 +257,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.46.1_imrg37k3svwu377c6q7gkarwmi
       '@typescript-eslint/parser': 5.46.1_ha6vam6werchizxrnqvarmz2zu
       '@watergis/svelte-maplibre-menu': link:../menu
+      '@watergis/svelte-maplibre-style-switcher': link:../style-switcher
       bulma: 0.9.4
       bulma-switch: 2.0.4
       eslint: 8.29.0

--- a/sites/svelte.water-gis.com/src/lib/components/LegendExample.svelte
+++ b/sites/svelte.water-gis.com/src/lib/components/LegendExample.svelte
@@ -84,7 +84,6 @@
 		<div class="legend-content" style="height:{menuHeight - 56}px">
 			<LegendPanel
 				bind:map
-				{style}
 				bind:onlyRendered
 				bind:onlyRelative
 				{relativeLayers}

--- a/sites/svelte.water-gis.com/src/routes/components/legend/+page.md
+++ b/sites/svelte.water-gis.com/src/routes/components/legend/+page.md
@@ -109,7 +109,6 @@ pnpm i @watergis/svelte-maplibre-legend
 		<div class="legend-content" style="height:{menuHeight - 56}px">
 			<LegendPanel
 				bind:map
-				{style}
 				bind:onlyRendered
 				bind:onlyRelative
 				{relativeLayers}
@@ -154,4 +153,12 @@ pnpm i @watergis/svelte-maplibre-legend
 		}
 	}
 </style>
+```
+
+### In case style.json is changed
+
+When you changed map style.json, please fire `style:change` event like the following source code. this legend panel watch this event and will recreate legend with new style.json.
+
+```shell
+map.on('style:change')
 ```


### PR DESCRIPTION
- [breaking change] deleted `style` parameter to be exported in order to fix the bug of style editor after switching to different style
- [breaking change] watch `style:change` custom event of maplibre map object to recreate legend panel.

When you changed map style.json, please fire `style:change` event like the following source code.

```
map.on('style:change')
```