### PR TITLE
fix: bug of export PDF of A3 size

### DIFF
--- a/.changeset/slow-donuts-speak.md
+++ b/.changeset/slow-donuts-speak.md
@@ -1,0 +1,5 @@
+---
+"@watergis/svelte-maplibre-export": patch
+---
+
+fix: fixed the bug of export PDF of A3 size spondered by @PivnoyBaronDmitry through the PR of https://github.com/watergis/mapbox-gl-export/pull/48

--- a/packages/export/src/lib/utils/map-generator.ts
+++ b/packages/export/src/lib/utils/map-generator.ts
@@ -237,7 +237,8 @@ export default class MapGenerator {
 		const pdf = new jsPDF({
 			orientation: this.width > this.height ? 'l' : 'p',
 			unit: this.unit,
-			compress: true
+			compress: true,
+			format: [this.width, this.height]
 		});
 
 		pdf.addImage(


### PR DESCRIPTION
## Description

fixed the bug of export PDF of A3 size spondered by @PivnoyBaronDmitry through the PR of https://github.com/watergis/mapbox-gl-export/pull/48

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

#### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

#### Verify the followings

<!-- ignore-task-list-start -->

- [x] Have you referenced related issues in the repo if they are present ([issues](https://github.com/watergis/svelte-maplibre-components/issues))?
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [x] Updated documentation in the packages you modified in [sites/svelte.water-gis.com](sites/svelte.water-gis.com) folder and `README.md` of the package.
<!-- ignore-task-list-end -->

#### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


