### PR TITLE
fix: recreate maplibre control object once map object is available

### DIFF
--- a/.changeset/tall-rocks-fix.md
+++ b/.changeset/tall-rocks-fix.md
@@ -1,0 +1,5 @@
+---
+"@watergis/svelte-maplibre-menu": patch
+---
+
+fix: recreate maplibre control object once map object is available

--- a/packages/menu/src/lib/MenuControl.svelte
+++ b/packages/menu/src/lib/MenuControl.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Map } from 'maplibre-gl';
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import { Split } from '@geoffcox/svelte-splitter/src';
 	import Fa from 'svelte-fa';
 	import {
@@ -74,19 +74,31 @@
 	// @ts-ignore
 	let mapMenuControl: MapMenuControl = null;
 
-	$: {
+	onMount(() => {
+		initControl()
+	});
+
+	$:if (map) {
+		initControl()
+	}
+
+	const initControl = () => {
 		if (map) {
-			if (mapMenuControl !== null && map.hasControl(mapMenuControl) === false) {
+			if (!(mapMenuControl && map.hasControl(mapMenuControl))) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				mapMenuControl = new MapMenuControl();
 				map.addControl(mapMenuControl, position);
 			}
 		}
 	}
 
-	onMount(async () => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		mapMenuControl = new MapMenuControl();
-		setSplitControl();
+	onDestroy(() => {
+		if (map) {
+			if (mapMenuControl && map.hasControl(mapMenuControl)) {
+				map.removeControl(mapMenuControl);
+			}
+		}
 	});
 
 	const resizeMap = () => {


### PR DESCRIPTION
## Description

Please describe what you changed briefly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

#### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

#### Verify the followings

<!-- ignore-task-list-start -->

- [x] Have you referenced related issues in the repo if they are present ([issues](https://github.com/watergis/svelte-maplibre-components/issues))?
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [x] Updated documentation in the packages you modified in [sites/svelte.water-gis.com](sites/svelte.water-gis.com) folder and `README.md` of the package.
<!-- ignore-task-list-end -->

#### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


