### PR TITLE
refactor: use mapstore context and layer id context

### DIFF
--- a/.changeset/polite-eyes-explain.md
+++ b/.changeset/polite-eyes-explain.md
@@ -2,4 +2,7 @@
 "@watergis/svelte-maplibre-legend": patch
 ---
 
-refactor: use mapstore as context other than passing as prop
+- refactor: use mapstore as context other than passing as prop
+- refactor: add index.ts in editor-panels
+- fix: add pmtiles library in example
+- fixed typescript error

--- a/.changeset/polite-eyes-explain.md
+++ b/.changeset/polite-eyes-explain.md
@@ -1,0 +1,5 @@
+---
+"@watergis/svelte-maplibre-legend": patch
+---
+
+refactor: use mapstore as context other than passing as prop

--- a/.changeset/polite-eyes-explain.md
+++ b/.changeset/polite-eyes-explain.md
@@ -6,3 +6,4 @@
 - refactor: add index.ts in editor-panels
 - fix: add pmtiles library in example
 - fixed typescript error
+- refactor: set layerId in context, and to use it in all style editing components. Now layer prop was removed.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[svelte]": {
+    "editor.defaultFormatter": "svelte.svelte-vscode",
+    "editor.codeActionsOnSave": ["source.organizeImports"]
+  }
 }

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -14,8 +14,8 @@
 		"build": "svelte-kit sync && svelte-package",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"lint": "prettier --check . && eslint .",
+		"format": "prettier --write ."
 	},
 	"repository": {
 		"type": "git",
@@ -53,6 +53,7 @@
 		"eslint": "^8.46.0",
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-svelte": "^2.32.4",
+		"pmtiles": "^2.10.0",
 		"prettier": "^3.0.0",
 		"prettier-plugin-svelte": "^3.0.3",
 		"sass": "^1.64.1",

--- a/packages/legend/src/example/Map.svelte
+++ b/packages/legend/src/example/Map.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { Map } from 'maplibre-gl';
+	import { LegendHeader, LegendPanel } from '$lib';
 	import { MenuControl } from '@watergis/svelte-maplibre-menu';
-	import { LegendPanel, LegendHeader } from '$lib';
 	import {
 		StyleSwitcher,
 		StyleUrl,
 		type StyleSwitcherOption
 	} from '@watergis/svelte-maplibre-style-switcher';
+	import maplibregl, { Map } from 'maplibre-gl';
+	import * as pmtiles from 'pmtiles';
+	import { onMount } from 'svelte';
+
+	let protocol = new pmtiles.Protocol();
+	maplibregl.addProtocol('pmtiles', protocol.tile);
 
 	let mapContainer: HTMLDivElement;
 	let map: Map;
@@ -126,7 +130,7 @@
 <style lang="scss">
 	@import 'maplibre-gl/dist/maplibre-gl.css';
 	@import 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css';
-	
+
 	.map {
 		position: absolute;
 		top: 0;

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -1,3 +1,18 @@
+<script context="module" lang="ts">
+	import { getContext, setContext } from 'svelte';
+
+	const LAYERID_CONTEXT_KEY = 'maplibre-legend-layer-id';
+
+	export const getLayerIdContext = () => {
+		const layerId: string = getContext(LAYERID_CONTEXT_KEY);
+		return layerId;
+	};
+
+	export const setLayerIdContext = (layerId: string) => {
+		setContext(LAYERID_CONTEXT_KEY, layerId);
+	};
+</script>
+
 <script lang="ts">
 	import {
 		faEye,
@@ -8,7 +23,7 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import { isMobile } from 'detect-touch-device';
 	import type { LayerSpecification } from 'maplibre-gl';
-	import { createEventDispatcher, setContext } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 	import Fa from 'svelte-fa';
 	import Legend from './Legend.svelte';
 	import { getMapContext } from './LegendPanel.svelte';
@@ -27,7 +42,7 @@
 	export let selectedFormat: 'yaml' | 'json';
 
 	const mapStore = getMapContext();
-	setContext('layerId', layer.id);
+	setLayerIdContext(layer.id);
 
 	let visibility = $mapStore?.getLayer(layer.id).visibility;
 
@@ -137,7 +152,9 @@
 		{/if}
 	{/if}
 	<div class="legend">
-		<Legend {layer} {spriteLoader} />
+		{#if $mapStore}
+			<Legend {layer} {spriteLoader} />
+		{/if}
 	</div>
 	<div class="layer-name">
 		{layerTitle}
@@ -173,7 +190,9 @@
 			{/if}
 		</div>
 	{:else if enableEditing === true}
-		<StyleEditor bind:layer bind:spriteLoader bind:selectedFormat bind:relativeLayers />
+		{#if $mapStore}
+			<StyleEditor {layer} bind:spriteLoader bind:selectedFormat bind:relativeLayers />
+		{/if}
 	{/if}
 </div>
 

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
 	import {
 		faEye,
 		faEyeSlash,
@@ -9,9 +8,10 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import { isMobile } from 'detect-touch-device';
 	import type { LayerSpecification } from 'maplibre-gl';
-	import { createEventDispatcher, getContext, setContext } from 'svelte';
+	import { createEventDispatcher, setContext } from 'svelte';
 	import Fa from 'svelte-fa';
 	import Legend from './Legend.svelte';
+	import { getMapContext } from './LegendPanel.svelte';
 	import StyleEditor from './StyleEditor.svelte';
 	import type SpriteLoader from './sprite';
 	import { clean } from './util/clean';
@@ -26,7 +26,7 @@
 	export let enableEditing = true;
 	export let selectedFormat: 'yaml' | 'json';
 
-	let mapStore: ReturnType<typeof createMapStore> = getContext('map');
+	const mapStore = getMapContext();
 	setContext('layerId', layer.id);
 
 	let visibility = $mapStore?.getLayer(layer.id).visibility;

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -153,7 +153,7 @@
 	{/if}
 	<div class="legend">
 		{#if $mapStore}
-			<Legend {layer} {spriteLoader} />
+			<Legend {spriteLoader} />
 		{/if}
 	</div>
 	<div class="layer-name">

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -9,7 +9,7 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import { isMobile } from 'detect-touch-device';
 	import type { LayerSpecification } from 'maplibre-gl';
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import Fa from 'svelte-fa';
 	import Legend from './Legend.svelte';
 	import StyleEditor from './StyleEditor.svelte';
@@ -27,6 +27,7 @@
 	export let selectedFormat: 'yaml' | 'json';
 
 	let mapStore: ReturnType<typeof createMapStore> = getContext('map');
+	setContext('layerId', layer.id);
 
 	let visibility = $mapStore?.getLayer(layer.id).visibility;
 

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -191,7 +191,7 @@
 		</div>
 	{:else if enableEditing === true}
 		{#if $mapStore}
-			<StyleEditor {layer} bind:spriteLoader bind:selectedFormat bind:relativeLayers />
+			<StyleEditor bind:spriteLoader bind:selectedFormat bind:relativeLayers />
 		{/if}
 	{/if}
 </div>

--- a/packages/legend/src/lib/Layer.svelte
+++ b/packages/legend/src/lib/Layer.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Fa from 'svelte-fa';
+	import type { createMapStore } from '$lib/stores';
 	import {
 		faEye,
 		faEyeSlash,
-		faSortUp,
+		faGripVertical,
 		faSortDown,
-		faGripVertical
+		faSortUp
 	} from '@fortawesome/free-solid-svg-icons';
-	import Legend from './Legend.svelte';
-	import type SpriteLoader from './sprite';
 	import { isMobile } from 'detect-touch-device';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { createEventDispatcher, getContext } from 'svelte';
+	import Fa from 'svelte-fa';
+	import Legend from './Legend.svelte';
 	import StyleEditor from './StyleEditor.svelte';
+	import type SpriteLoader from './sprite';
 	import { clean } from './util/clean';
 
 	const dispatch = createEventDispatcher();
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 	export let spriteLoader: SpriteLoader;
 	export let relativeLayers: { [key: string]: string } = {};
@@ -25,7 +25,10 @@
 	export let disableVisibleButton = false;
 	export let enableEditing = true;
 	export let selectedFormat: 'yaml' | 'json';
-	let visibility = map.getLayer(layer.id).visibility;
+
+	let mapStore: ReturnType<typeof createMapStore> = getContext('map');
+
+	let visibility = $mapStore?.getLayer(layer.id).visibility;
 
 	let checked = visibility === 'none' ? false : true;
 	$: checked, setVisibility();
@@ -35,7 +38,7 @@
 
 	const setVisibility = () => {
 		const visibility = checked === true ? 'visible' : 'none';
-		map.setLayoutProperty(layer.id, 'visibility', visibility);
+		mapStore.setLayoutProperty(layer.id, 'visibility', visibility);
 		dispatch('visibilityChanged', {
 			layer,
 			visibility
@@ -49,13 +52,13 @@
 	};
 
 	const getLayerIndex = () => {
-		const layers = map?.getStyle()?.layers;
+		const layers = $mapStore?.getStyle()?.layers;
 		const index = layers?.findIndex((l) => l.id === layer.id);
 		return index;
 	};
 
 	const getTotalCount = () => {
-		return map?.getStyle()?.layers.length;
+		return $mapStore?.getStyle()?.layers.length;
 	};
 
 	const checkIsFirstLayer = () => {
@@ -64,7 +67,7 @@
 	};
 
 	const checkIsLastLayer = () => {
-		const layers = map?.getStyle()?.layers;
+		const layers = $mapStore?.getStyle()?.layers;
 		const index = getLayerIndex();
 		return index === layers.length - 1;
 	};
@@ -74,9 +77,9 @@
 
 	const moveBefore = () => {
 		const currentIndex = getLayerIndex();
-		const layers = map?.getStyle()?.layers;
+		const layers = $mapStore?.getStyle()?.layers;
 		const beforeLayerId = layers[currentIndex - 1].id;
-		map.moveLayer(layer.id, beforeLayerId);
+		$mapStore.moveLayer(layer.id, beforeLayerId);
 		isFirstLater = checkIsFirstLayer();
 		isLastLayer = checkIsLastLayer();
 		dispatch('layerOrderChanged');
@@ -90,9 +93,9 @@
 
 	const moveAfter = () => {
 		const currentIndex = getLayerIndex();
-		const layers = map?.getStyle()?.layers;
+		const layers = $mapStore?.getStyle()?.layers;
 		const afterLayerId = layers[currentIndex + 1].id;
-		map.moveLayer(afterLayerId, layer.id);
+		$mapStore.moveLayer(afterLayerId, layer.id);
 		isFirstLater = checkIsFirstLayer();
 		isLastLayer = checkIsLastLayer();
 		dispatch('layerOrderChanged');
@@ -133,7 +136,7 @@
 		{/if}
 	{/if}
 	<div class="legend">
-		<Legend {map} {layer} {spriteLoader} />
+		<Legend {layer} {spriteLoader} />
 	</div>
 	<div class="layer-name">
 		{layerTitle}
@@ -169,7 +172,7 @@
 			{/if}
 		</div>
 	{:else if enableEditing === true}
-		<StyleEditor bind:map bind:layer bind:spriteLoader bind:selectedFormat bind:relativeLayers />
+		<StyleEditor bind:layer bind:spriteLoader bind:selectedFormat bind:relativeLayers />
 	{/if}
 </div>
 
@@ -202,7 +205,13 @@
 		}
 
 		.layer-name {
-			font-family: system-ui, -apple-system, system-ui, 'Helvetica Neue', Helvetica, Arial,
+			font-family:
+				system-ui,
+				-apple-system,
+				system-ui,
+				'Helvetica Neue',
+				Helvetica,
+				Arial,
 				sans-serif;
 			font-size: 16px;
 			font-weight: 400;

--- a/packages/legend/src/lib/Legend.svelte
+++ b/packages/legend/src/lib/Legend.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
 	import type { LayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	import LegendSymbol from '@watergis/legend-symbol';
 	import chroma from 'chroma-js';
-	import { getContext } from 'svelte';
+	import { getMapContext } from './LegendPanel.svelte';
 	import type SpriteLoader from './sprite';
 	import { getColorFromExpression } from './util/getColorFromExpression';
 
-	let mapStore: ReturnType<typeof createMapStore> = getContext('map');
+	const mapStore = getMapContext();
 
 	export let layer: LayerSpecification;
 	export let spriteLoader: SpriteLoader;

--- a/packages/legend/src/lib/Legend.svelte
+++ b/packages/legend/src/lib/Legend.svelte
@@ -4,16 +4,16 @@
 	// @ts-ignore
 	import LegendSymbol from '@watergis/legend-symbol';
 	import chroma from 'chroma-js';
+	import { getLayerIdContext } from './Layer.svelte';
 	import { getMapContext } from './LegendPanel.svelte';
 	import type SpriteLoader from './sprite';
 	import { getColorFromExpression } from './util/getColorFromExpression';
 
 	const mapStore = getMapContext();
+	const layerId = getLayerIdContext();
 
-	export let layer: LayerSpecification;
 	export let spriteLoader: SpriteLoader;
 	let container: HTMLElement = document.createElement('div');
-	$: layer, update();
 
 	const createSvgIcon = (svgXmlString: string) => {
 		let blob = new Blob([svgXmlString], { type: 'image/svg+xml' });
@@ -26,7 +26,12 @@
 		return image;
 	};
 
-	const update = async () => {
+	const update = () => {
+		const layer: LayerSpecification = $mapStore
+			.getStyle()
+			.layers.find((l: LayerSpecification) => l.id === layerId);
+		if (!layer) return;
+
 		const zoom = $mapStore.getZoom();
 		const symbol = LegendSymbol({ zoom: zoom, layer: layer });
 		container.innerText = '';
@@ -151,6 +156,7 @@
 		}
 	};
 
+	$mapStore.on('styledata', update);
 	$mapStore.on('moveend', update);
 	$mapStore.on('zoom', update);
 </script>

--- a/packages/legend/src/lib/Legend.svelte
+++ b/packages/legend/src/lib/Legend.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import type { LayerSpecification } from 'maplibre-gl';
+	import type { createMapStore } from '$lib/stores';
+	import type { LayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
-	import type { createMapStore } from '$lib/stores';
 	import LegendSymbol from '@watergis/legend-symbol';
 	import chroma from 'chroma-js';
 	import { getContext } from 'svelte';
@@ -73,7 +73,7 @@
 				}
 			} else {
 				const color = $mapStore.getPaintProperty(layer.id, 'background-color');
-				const value = getColorFromExpression(color) ?? '#000000';
+				const value: string = (getColorFromExpression(color) as string) ?? '#000000';
 
 				const opacity = $mapStore.getPaintProperty(layer.id, 'background-opacity') ?? 1;
 
@@ -112,7 +112,7 @@
 					break;
 				case 'svg':
 					if (spriteLoader) {
-						dataUrl = spriteLoader.getIconDataUrl(layer);
+						dataUrl = spriteLoader.getIconDataUrl(layer as SymbolLayerSpecification);
 						if (dataUrl) {
 							const img = document.createElement('img');
 							img.src = dataUrl;

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -17,8 +17,8 @@
 </script>
 
 <script lang="ts">
-	import { invisibleLayerMap } from '$lib/stores';
 	import type { LayerSpecification, Map, StyleSpecification } from 'maplibre-gl';
+	import { writable } from 'svelte/store';
 	import Layer from './Layer.svelte';
 	import SpriteLoader from './sprite';
 	import { distinct } from './util/distinct';
@@ -31,6 +31,7 @@
 	export let enableEditing = true;
 
 	const mapStore = setMapContext();
+	const invisibleLayerMap = writable<{ [key: string]: LayerSpecification }>({});
 
 	let style: StyleSpecification;
 	let spriteLoader: SpriteLoader | undefined;

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import type { StyleSpecification, LayerSpecification, Map } from 'maplibre-gl';
+	import { createMapStore, invisibleLayerMap } from '$lib/stores';
+	import type { LayerSpecification, Map, StyleSpecification } from 'maplibre-gl';
+	import { setContext } from 'svelte';
 	import Layer from './Layer.svelte';
 	import SpriteLoader from './sprite';
-	import { invisibleLayerMap, createMapStore } from '$lib/stores';
 	import { distinct } from './util/distinct';
-	import { setContext } from 'svelte';
 
 	export let map: Map;
 	export let onlyRendered = true;
@@ -13,8 +13,8 @@
 	export let disableVisibleButton = false;
 	export let enableEditing = true;
 
-	let mapStore: ReturnType<typeof createMapStore> = createMapStore()
-	setContext('map', mapStore)
+	let mapStore: ReturnType<typeof createMapStore> = createMapStore();
+	setContext('map', mapStore);
 
 	let style: StyleSpecification;
 	let spriteLoader: SpriteLoader | undefined;
@@ -28,7 +28,7 @@
 
 	$: {
 		if (map) {
-			mapStore.set(map)
+			mapStore.set(map);
 
 			$mapStore.on('moveend', updateLayers);
 			$mapStore.on('styledata', updateLayers);
@@ -116,10 +116,10 @@
 
 	const drop = (
 		/* eslint-disable @typescript-eslint/no-explicit-any */
-		event: any, 
-		target: number, 
+		event: any,
+		target: number,
 		layer?: LayerSpecification
-		) => {
+	) => {
 		event.dataTransfer.dropEffect = 'move';
 		const start = parseInt(event.dataTransfer.getData('text/plain'));
 		const newTracklist = allLayers;
@@ -146,9 +146,9 @@
 
 	const dragstart = (
 		/* eslint-disable @typescript-eslint/no-explicit-any */
-		event: any, 
+		event: any,
 		i: number
-		) => {
+	) => {
 		event.dataTransfer.effectAllowed = 'move';
 		event.dataTransfer.dropEffect = 'move';
 		const start = i;
@@ -223,7 +223,7 @@
 </script>
 
 <ul class="legend-panel">
-	{#if spriteLoader}
+	{#if $mapStore && spriteLoader}
 		{#key style}
 			{#each allLayers as layer, index (layer.id)}
 				{#if showOnList(layer.id)}

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -4,7 +4,7 @@
 
 	const MAP_CONTEXT_KEY = 'maplibre-legend-map';
 
-	export const getMapContext = () => {
+	export const getMapContext = (): ReturnType<typeof createMapStore> => {
 		const mapStore: ReturnType<typeof createMapStore> = getContext(MAP_CONTEXT_KEY);
 		return mapStore;
 	};

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -1,7 +1,24 @@
+<script context="module" lang="ts">
+	import { createMapStore } from '$lib/stores';
+	import { getContext, setContext } from 'svelte';
+
+	const MAP_CONTEXT_KEY = 'maplibre-legend-map';
+
+	export const getMapContext = () => {
+		const mapStore: ReturnType<typeof createMapStore> = getContext(MAP_CONTEXT_KEY);
+		return mapStore;
+	};
+
+	export const setMapContext = () => {
+		let mapStore: ReturnType<typeof createMapStore> = createMapStore();
+		setContext(MAP_CONTEXT_KEY, mapStore);
+		return mapStore;
+	};
+</script>
+
 <script lang="ts">
-	import { createMapStore, invisibleLayerMap } from '$lib/stores';
+	import { invisibleLayerMap } from '$lib/stores';
 	import type { LayerSpecification, Map, StyleSpecification } from 'maplibre-gl';
-	import { setContext } from 'svelte';
 	import Layer from './Layer.svelte';
 	import SpriteLoader from './sprite';
 	import { distinct } from './util/distinct';
@@ -13,8 +30,7 @@
 	export let disableVisibleButton = false;
 	export let enableEditing = true;
 
-	let mapStore: ReturnType<typeof createMapStore> = createMapStore();
-	setContext('map', mapStore);
+	const mapStore = setMapContext();
 
 	let style: StyleSpecification;
 	let spriteLoader: SpriteLoader | undefined;

--- a/packages/legend/src/lib/LegendPanel.svelte
+++ b/packages/legend/src/lib/LegendPanel.svelte
@@ -88,11 +88,14 @@
 		if (onlyRendered === true) {
 			Object.keys($invisibleLayerMap).forEach((layerId) => {
 				visibleLayerMap[layerId] = $invisibleLayerMap[layerId];
+				if ($mapStore.getLayer(layerId)) {
+					mapStore.setLayoutProperty(layerId, 'visibility', 'none');
+				}
 			});
 			const features = $mapStore.queryRenderedFeatures();
 			const ids = features.map((f) => f.layer.id).filter(distinct);
 			const zoom = $mapStore.getZoom();
-			all.forEach((layer) => {
+			all.forEach((layer: LayerSpecification) => {
 				const minzoom = layer.minzoom ?? 0;
 				const maxzoom = layer.maxzoom ?? 24;
 				if (ids.indexOf(layer.id) !== -1) {
@@ -104,7 +107,7 @@
 				}
 			});
 		} else {
-			all.forEach((layer) => {
+			all.forEach((layer: LayerSpecification) => {
 				visibleLayerMap[layer.id] = layer;
 			});
 		}

--- a/packages/legend/src/lib/StyleEditor.svelte
+++ b/packages/legend/src/lib/StyleEditor.svelte
@@ -1,26 +1,25 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
+	import { faCircleXmark, faPalette, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
+	import type { LayerSpecification } from 'maplibre-gl';
 	import Fa from 'svelte-fa';
-	import { faPalette, faCircleXmark, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
-	import BackgroundEditor from './editor-panels/BackgroundEditor.svelte';
-	import FillEditor from './editor-panels/FillEditor.svelte';
-	import LineEditor from './editor-panels/LineEditor.svelte';
-	import CircleEditor from './editor-panels/CircleEditor.svelte';
-	import SymbolEditor from './editor-panels/SymbolEditor.svelte';
-	import FillExtrusionEditor from './editor-panels/FillExtrusionEditor.svelte';
-	import HillshadeEditor from './editor-panels/HillshadeEditor.svelte';
-	import type SpriteLoader from './sprite';
-	import RasterEditor from './editor-panels/RasterEditor.svelte';
-	import HeatmapEditor from './editor-panels/HeatmapEditor.svelte';
-	import Help from './util/Help.svelte';
-	import ManualEditor from './editor-panels/ManualEditor.svelte';
-	import { initTippy } from './util/initTippy';
 	import 'tippy.js/dist/tippy.css';
 	import 'tippy.js/themes/light.css';
 	import Legend from './Legend.svelte';
+	import BackgroundEditor from './editor-panels/BackgroundEditor.svelte';
+	import CircleEditor from './editor-panels/CircleEditor.svelte';
+	import FillEditor from './editor-panels/FillEditor.svelte';
+	import FillExtrusionEditor from './editor-panels/FillExtrusionEditor.svelte';
+	import HeatmapEditor from './editor-panels/HeatmapEditor.svelte';
+	import HillshadeEditor from './editor-panels/HillshadeEditor.svelte';
+	import LineEditor from './editor-panels/LineEditor.svelte';
+	import ManualEditor from './editor-panels/ManualEditor.svelte';
+	import RasterEditor from './editor-panels/RasterEditor.svelte';
+	import SymbolEditor from './editor-panels/SymbolEditor.svelte';
+	import type SpriteLoader from './sprite';
+	import Help from './util/Help.svelte';
 	import { clean } from './util/clean';
+	import { initTippy } from './util/initTippy';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 	export let spriteLoader: SpriteLoader;
 	export let relativeLayers: { [key: string]: string };
@@ -58,7 +57,7 @@
 <div class="tooltip" bind:this={tooltipContent}>
 	<div class="title">
 		<div class="legend">
-			<Legend {map} {layer} {spriteLoader} />
+			<Legend {layer} {spriteLoader} />
 		</div>
 		<div class="layer-name">
 			{layerTitle}
@@ -92,25 +91,25 @@
 
 	<div class="editor-contents">
 		{#if showManualEditor}
-			<ManualEditor bind:map bind:layer bind:selectedFormat />
+			<ManualEditor bind:layer bind:selectedFormat />
 		{:else if layer.type === 'background'}
-			<BackgroundEditor bind:map bind:layer />
+			<BackgroundEditor bind:layer />
 		{:else if layer.type === 'fill'}
-			<FillEditor bind:map bind:layer />
+			<FillEditor bind:layer />
 		{:else if layer.type === 'line'}
-			<LineEditor bind:map bind:layer />
+			<LineEditor bind:layer />
 		{:else if layer.type === 'symbol'}
-			<SymbolEditor bind:map bind:layer bind:spriteLoader />
+			<SymbolEditor bind:layer bind:spriteLoader />
 		{:else if layer.type === 'circle'}
-			<CircleEditor bind:map bind:layer />
+			<CircleEditor bind:layer />
 		{:else if layer.type === 'fill-extrusion'}
-			<FillExtrusionEditor bind:map bind:layer />
+			<FillExtrusionEditor bind:layer />
 		{:else if layer.type === 'hillshade'}
-			<HillshadeEditor bind:map bind:layer />
+			<HillshadeEditor bind:layer />
 		{:else if layer.type === 'raster'}
-			<RasterEditor bind:map bind:layer />
+			<RasterEditor bind:layer />
 		{:else if layer.type === 'heatmap'}
-			<HeatmapEditor bind:map bind:layer />
+			<HeatmapEditor bind:layer />
 		{/if}
 	</div>
 	<div id="arrow" data-popper-arrow />

--- a/packages/legend/src/lib/StyleEditor.svelte
+++ b/packages/legend/src/lib/StyleEditor.svelte
@@ -4,7 +4,9 @@
 	import Fa from 'svelte-fa';
 	import 'tippy.js/dist/tippy.css';
 	import 'tippy.js/themes/light.css';
+	import { getLayerIdContext } from './Layer.svelte';
 	import Legend from './Legend.svelte';
+	import { getMapContext } from './LegendPanel.svelte';
 	import {
 		BackgroundEditor,
 		CircleEditor,
@@ -22,7 +24,12 @@
 	import { clean } from './util/clean';
 	import { initTippy } from './util/initTippy';
 
-	export let layer: LayerSpecification;
+	const mapStore = getMapContext();
+	const layerId = getLayerIdContext();
+
+	let layer: LayerSpecification = $mapStore
+		.getStyle()
+		.layers.find((l: LayerSpecification) => l.id === layerId);
 	export let spriteLoader: SpriteLoader;
 	export let relativeLayers: { [key: string]: string };
 	let showManualEditor = false;

--- a/packages/legend/src/lib/StyleEditor.svelte
+++ b/packages/legend/src/lib/StyleEditor.svelte
@@ -93,25 +93,25 @@
 
 	<div class="editor-contents">
 		{#if showManualEditor}
-			<ManualEditor bind:layer bind:selectedFormat />
+			<ManualEditor bind:selectedFormat />
 		{:else if layer.type === 'background'}
-			<BackgroundEditor bind:layer />
+			<BackgroundEditor />
 		{:else if layer.type === 'fill'}
-			<FillEditor bind:layer />
+			<FillEditor />
 		{:else if layer.type === 'line'}
-			<LineEditor bind:layer />
+			<LineEditor />
 		{:else if layer.type === 'symbol'}
-			<SymbolEditor bind:layer bind:spriteLoader />
+			<SymbolEditor bind:spriteLoader />
 		{:else if layer.type === 'circle'}
-			<CircleEditor bind:layer />
+			<CircleEditor />
 		{:else if layer.type === 'fill-extrusion'}
-			<FillExtrusionEditor bind:layer />
+			<FillExtrusionEditor />
 		{:else if layer.type === 'hillshade'}
-			<HillshadeEditor bind:layer />
+			<HillshadeEditor />
 		{:else if layer.type === 'raster'}
-			<RasterEditor bind:layer />
+			<RasterEditor />
 		{:else if layer.type === 'heatmap'}
-			<HeatmapEditor bind:layer />
+			<HeatmapEditor />
 		{/if}
 	</div>
 	<div id="arrow" data-popper-arrow />

--- a/packages/legend/src/lib/StyleEditor.svelte
+++ b/packages/legend/src/lib/StyleEditor.svelte
@@ -5,16 +5,18 @@
 	import 'tippy.js/dist/tippy.css';
 	import 'tippy.js/themes/light.css';
 	import Legend from './Legend.svelte';
-	import BackgroundEditor from './editor-panels/BackgroundEditor.svelte';
-	import CircleEditor from './editor-panels/CircleEditor.svelte';
-	import FillEditor from './editor-panels/FillEditor.svelte';
-	import FillExtrusionEditor from './editor-panels/FillExtrusionEditor.svelte';
-	import HeatmapEditor from './editor-panels/HeatmapEditor.svelte';
-	import HillshadeEditor from './editor-panels/HillshadeEditor.svelte';
-	import LineEditor from './editor-panels/LineEditor.svelte';
-	import ManualEditor from './editor-panels/ManualEditor.svelte';
-	import RasterEditor from './editor-panels/RasterEditor.svelte';
-	import SymbolEditor from './editor-panels/SymbolEditor.svelte';
+	import {
+		BackgroundEditor,
+		CircleEditor,
+		FillEditor,
+		FillExtrusionEditor,
+		HeatmapEditor,
+		HillshadeEditor,
+		LineEditor,
+		ManualEditor,
+		RasterEditor,
+		SymbolEditor
+	} from './editor-panels';
 	import type SpriteLoader from './sprite';
 	import Help from './util/Help.svelte';
 	import { clean } from './util/clean';

--- a/packages/legend/src/lib/StyleEditor.svelte
+++ b/packages/legend/src/lib/StyleEditor.svelte
@@ -59,7 +59,7 @@
 <div class="tooltip" bind:this={tooltipContent}>
 	<div class="title">
 		<div class="legend">
-			<Legend {layer} {spriteLoader} />
+			<Legend {spriteLoader} />
 		</div>
 		<div class="layer-name">
 			{layerTitle}

--- a/packages/legend/src/lib/editor-controls/ColorControl.svelte
+++ b/packages/legend/src/lib/editor-controls/ColorControl.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
-	import { debounce } from 'lodash-es';
+	import type { createMapStore } from '$lib/stores';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import { getColorFromExpression } from '$lib/util/getColorFromExpression';
+	import { debounce } from 'lodash-es';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 	export let propertyName:
 		| 'background-color'
@@ -23,7 +26,7 @@
 		| 'hillshade-shadow-color';
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, propertyName);
+		let value = $map.getPaintProperty(layer.id, propertyName);
 		value = getColorFromExpression(value);
 
 		if (!value) {
@@ -32,19 +35,19 @@
 
 		if (value && typeof value === 'object') {
 			if ('stops' in value) {
-				const expr = value as {base: number, stops: [number, string][]}
-				const stops = expr.stops as [number, string][]
-				stops.forEach(stop=>{
+				const expr = value as { base: number; stops: [number, string][] };
+				const stops = expr.stops as [number, string][];
+				stops.forEach((stop) => {
 					stop[1] = getColorFromExpression(stop[1]) as string;
-				})
-				return expr
+				});
+				return expr;
 			}
 		}
 
 		return value as string;
 	};
 
-	let color: string |  {base: number, stops: [number, string][]} = getValue();
+	let color: string | { base: number; stops: [number, string][] } = getValue();
 
 	const handleColorChanged = debounce((e: { detail: { color: string } }) => {
 		if (typeof color === 'string') {
@@ -53,7 +56,7 @@
 		} else {
 			map.setPaintProperty(layer.id, propertyName, color);
 		}
-		const newLayer = map.getStyle().layers.find((l) => l.id === layer.id);
+		const newLayer = $map.getStyle().layers.find((l) => l.id === layer.id);
 		if (newLayer) {
 			layer = newLayer;
 		}
@@ -61,22 +64,18 @@
 </script>
 
 {#if typeof color === 'string'}
-
-<ColorPicker bind:color on:change={handleColorChanged} />
-
+	<ColorPicker bind:color on:change={handleColorChanged} />
 {:else if 'stops' in color}
-
-{#each color.stops as stop}
-<div class="stop">
-	<p>{stop[0]}</p>
-	<ColorPicker bind:color={stop[1]} on:change={handleColorChanged} />
-</div>
-{/each}
-
+	{#each color.stops as stop}
+		<div class="stop">
+			<p>{stop[0]}</p>
+			<ColorPicker bind:color={stop[1]} on:change={handleColorChanged} />
+		</div>
+	{/each}
 {/if}
 
 <style lang="scss">
-	.stop{
+	.stop {
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		gap: 1px;

--- a/packages/legend/src/lib/editor-controls/ColorControl.svelte
+++ b/packages/legend/src/lib/editor-controls/ColorControl.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import { getColorFromExpression } from '$lib/util/getColorFromExpression';
 	import { debounce } from 'lodash-es';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	export let propertyName:
 		| 'background-color'

--- a/packages/legend/src/lib/editor-controls/ColorControl.svelte
+++ b/packages/legend/src/lib/editor-controls/ColorControl.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import { getColorFromExpression } from '$lib/util/getColorFromExpression';
 	import { debounce } from 'lodash-es';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	export let propertyName:

--- a/packages/legend/src/lib/editor-controls/ColorControl.svelte
+++ b/packages/legend/src/lib/editor-controls/ColorControl.svelte
@@ -3,12 +3,11 @@
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import { getColorFromExpression } from '$lib/util/getColorFromExpression';
 	import { debounce } from 'lodash-es';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
+	let layerId: string = getContext('layerId');
 
-	export let layer: LayerSpecification;
 	export let propertyName:
 		| 'background-color'
 		| 'fill-color'
@@ -26,7 +25,7 @@
 		| 'hillshade-shadow-color';
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, propertyName);
+		let value = $map.getPaintProperty(layerId, propertyName);
 		value = getColorFromExpression(value);
 
 		if (!value) {
@@ -52,13 +51,9 @@
 	const handleColorChanged = debounce((e: { detail: { color: string } }) => {
 		if (typeof color === 'string') {
 			color = e.detail.color;
-			map.setPaintProperty(layer.id, propertyName, color);
+			map.setPaintProperty(layerId, propertyName, color);
 		} else {
-			map.setPaintProperty(layer.id, propertyName, color);
-		}
-		const newLayer = $map.getStyle().layers.find((l) => l.id === layer.id);
-		if (newLayer) {
-			layer = newLayer;
+			map.setPaintProperty(layerId, propertyName, color);
 		}
 	}, 100);
 </script>

--- a/packages/legend/src/lib/editor-controls/Opacity.svelte
+++ b/packages/legend/src/lib/editor-controls/Opacity.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { debounce } from 'lodash-es';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	import type { createMapStore } from '$lib/stores';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getOpacity = () => {
-		const style = $map?.getStyle().layers.find((l) => l.id === layerId);
+		const style = $map?.getStyle().layers.find((l: LayerSpecification) => l.id === layerId);
 		let opacity;
 		switch (style?.type) {
 			case 'background':

--- a/packages/legend/src/lib/editor-controls/Opacity.svelte
+++ b/packages/legend/src/lib/editor-controls/Opacity.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { debounce } from 'lodash-es';
 	import type { LayerSpecification } from 'maplibre-gl';
 
-	import { getContext } from 'svelte';
-
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getOpacity = () => {
 		const style = $map?.getStyle().layers.find((l: LayerSpecification) => l.id === layerId);

--- a/packages/legend/src/lib/editor-controls/Opacity.svelte
+++ b/packages/legend/src/lib/editor-controls/Opacity.svelte
@@ -1,38 +1,42 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
-	import { debounce } from 'lodash-es';
 	import Slider from '$lib/util/Slider.svelte';
+	import { debounce } from 'lodash-es';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
+	import type { createMapStore } from '$lib/stores';
+	import { getContext } from 'svelte';
+
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getOpacity = () => {
-		const style = map?.getStyle().layers.find((l) => l.id === layer.id);
+		const style = $map?.getStyle().layers.find((l) => l.id === layer.id);
 		let opacity;
 		switch (style?.type) {
 			case 'background':
-				opacity = map.getPaintProperty(layer.id, 'background-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'background-opacity');
 				break;
 			case 'raster':
-				opacity = map.getPaintProperty(layer.id, 'raster-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'raster-opacity');
 				break;
 			case 'symbol':
-				opacity = map.getPaintProperty(layer.id, 'icon-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'icon-opacity');
 				break;
 			case 'line':
-				opacity = map.getPaintProperty(layer.id, 'line-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'line-opacity');
 				break;
 			case 'fill':
-				opacity = map.getPaintProperty(layer.id, 'fill-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'fill-opacity');
 				break;
 			case 'circle':
-				opacity = map.getPaintProperty(layer.id, 'circle-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'circle-opacity');
 				break;
 			case 'heatmap':
-				opacity = map.getPaintProperty(layer.id, 'heatmap-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'heatmap-opacity');
 				break;
 			case 'fill-extrusion':
-				opacity = map.getPaintProperty(layer.id, 'fill-extrusion-opacity');
+				opacity = $map.getPaintProperty(layer.id, 'fill-extrusion-opacity');
 				break;
 			default:
 				break;
@@ -49,7 +53,7 @@
 
 	const setOpacity = debounce(() => {
 		if (!value) return;
-		const style = map?.getStyle().layers.find((l) => l.id === layer.id);
+		const style = $map?.getStyle().layers.find((l) => l.id === layer.id);
 		switch (style?.type) {
 			case 'background':
 				map.setPaintProperty(layer.id, 'background-opacity', value);

--- a/packages/legend/src/lib/editor-controls/Opacity.svelte
+++ b/packages/legend/src/lib/editor-controls/Opacity.svelte
@@ -1,42 +1,40 @@
 <script lang="ts">
 	import Slider from '$lib/util/Slider.svelte';
 	import { debounce } from 'lodash-es';
-	import type { LayerSpecification } from 'maplibre-gl';
 
 	import type { createMapStore } from '$lib/stores';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getOpacity = () => {
-		const style = $map?.getStyle().layers.find((l) => l.id === layer.id);
+		const style = $map?.getStyle().layers.find((l) => l.id === layerId);
 		let opacity;
 		switch (style?.type) {
 			case 'background':
-				opacity = $map.getPaintProperty(layer.id, 'background-opacity');
+				opacity = $map.getPaintProperty(layerId, 'background-opacity');
 				break;
 			case 'raster':
-				opacity = $map.getPaintProperty(layer.id, 'raster-opacity');
+				opacity = $map.getPaintProperty(layerId, 'raster-opacity');
 				break;
 			case 'symbol':
-				opacity = $map.getPaintProperty(layer.id, 'icon-opacity');
+				opacity = $map.getPaintProperty(layerId, 'icon-opacity');
 				break;
 			case 'line':
-				opacity = $map.getPaintProperty(layer.id, 'line-opacity');
+				opacity = $map.getPaintProperty(layerId, 'line-opacity');
 				break;
 			case 'fill':
-				opacity = $map.getPaintProperty(layer.id, 'fill-opacity');
+				opacity = $map.getPaintProperty(layerId, 'fill-opacity');
 				break;
 			case 'circle':
-				opacity = $map.getPaintProperty(layer.id, 'circle-opacity');
+				opacity = $map.getPaintProperty(layerId, 'circle-opacity');
 				break;
 			case 'heatmap':
-				opacity = $map.getPaintProperty(layer.id, 'heatmap-opacity');
+				opacity = $map.getPaintProperty(layerId, 'heatmap-opacity');
 				break;
 			case 'fill-extrusion':
-				opacity = $map.getPaintProperty(layer.id, 'fill-extrusion-opacity');
+				opacity = $map.getPaintProperty(layerId, 'fill-extrusion-opacity');
 				break;
 			default:
 				break;
@@ -53,32 +51,32 @@
 
 	const setOpacity = debounce(() => {
 		if (!value) return;
-		const style = $map?.getStyle().layers.find((l) => l.id === layer.id);
+		const style = $map?.getStyle().layers.find((l) => l.id === layerId);
 		switch (style?.type) {
 			case 'background':
-				map.setPaintProperty(layer.id, 'background-opacity', value);
+				map.setPaintProperty(layerId, 'background-opacity', value);
 				break;
 			case 'raster':
-				map.setPaintProperty(layer.id, 'raster-opacity', value);
+				map.setPaintProperty(layerId, 'raster-opacity', value);
 				break;
 			case 'symbol':
-				map.setPaintProperty(layer.id, 'icon-opacity', value);
-				map.setPaintProperty(layer.id, 'text-opacity', value);
+				map.setPaintProperty(layerId, 'icon-opacity', value);
+				map.setPaintProperty(layerId, 'text-opacity', value);
 				break;
 			case 'line':
-				map.setPaintProperty(layer.id, 'line-opacity', value);
+				map.setPaintProperty(layerId, 'line-opacity', value);
 				break;
 			case 'fill':
-				map.setPaintProperty(layer.id, 'fill-opacity', value);
+				map.setPaintProperty(layerId, 'fill-opacity', value);
 				break;
 			case 'circle':
-				map.setPaintProperty(layer.id, 'circle-opacity', value);
+				map.setPaintProperty(layerId, 'circle-opacity', value);
 				break;
 			case 'heatmap':
-				map.setPaintProperty(layer.id, 'heatmap-opacity', value);
+				map.setPaintProperty(layerId, 'heatmap-opacity', value);
 				break;
 			case 'fill-extrusion':
-				map.setPaintProperty(layer.id, 'fill-extrusion-opacity', value);
+				map.setPaintProperty(layerId, 'fill-extrusion-opacity', value);
 				break;
 			default:
 				break;

--- a/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
+	import type { createMapStore } from './stores';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'circle-radius');
+		let value = $map.getPaintProperty(layer.id, 'circle-radius');
 
 		if (!value) {
 			value = 5;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'circle-radius', value);
+		map.setPaintProperty(layer.id, 'circle-radius', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
-	import type { createMapStore } from './stores';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 	import type { createMapStore } from './stores';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'circle-radius');
+		let value = $map.getPaintProperty(layerId, 'circle-radius');
 
 		if (!value) {
 			value = 5;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'circle-radius', value);
+		map.setPaintProperty(layerId, 'circle-radius', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleRadius.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'circle-radius');

--- a/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'circle-stroke-width');
+		let value = $map.getPaintProperty(layerId, 'circle-stroke-width');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'circle-stroke-width', value);
+		map.setPaintProperty(layerId, 'circle-stroke-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'circle-stroke-width');
+		let value = $map.getPaintProperty(layer.id, 'circle-stroke-width');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'circle-stroke-width', value);
+		map.setPaintProperty(layer.id, 'circle-stroke-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/circle/CircleStrokeWidth.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'circle-stroke-width');

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'fill-extrusion-base');
+		let value = $map.getPaintProperty(layer.id, 'fill-extrusion-base');
 
 		if (!value) {
 			value = 0;
@@ -18,7 +21,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'fill-extrusion-base', value);
+		map.setPaintProperty(layer.id, 'fill-extrusion-base', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'fill-extrusion-base');

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'fill-extrusion-base');
+		let value = $map.getPaintProperty(layerId, 'fill-extrusion-base');
 
 		if (!value) {
 			value = 0;
@@ -21,7 +19,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'fill-extrusion-base', value);
+		map.setPaintProperty(layerId, 'fill-extrusion-base', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'fill-extrusion-height');

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'fill-extrusion-height');
+		let value = $map.getPaintProperty(layer.id, 'fill-extrusion-height');
 
 		if (!value) {
 			value = 0;
@@ -18,7 +21,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'fill-extrusion-height', value);
+		map.setPaintProperty(layer.id, 'fill-extrusion-height', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'fill-extrusion-height');
+		let value = $map.getPaintProperty(layerId, 'fill-extrusion-height');
 
 		if (!value) {
 			value = 0;
@@ -21,7 +19,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'fill-extrusion-height', value);
+		map.setPaintProperty(layerId, 'fill-extrusion-height', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
+++ b/packages/legend/src/lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import chroma from 'chroma-js';
 	import { debounce } from 'lodash-es';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	type InterpolateType = number | string[] | string;

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import chroma from 'chroma-js';
 	import { debounce } from 'lodash-es';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	type InterpolateType = number | string[] | string;
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
@@ -3,12 +3,10 @@
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
 	import chroma from 'chroma-js';
 	import { debounce } from 'lodash-es';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	type InterpolateType = number | string[] | string;
 
@@ -17,7 +15,7 @@
 	const START_POSITION = 3;
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'heatmap-color') as InterpolateType[];
+		let value = $map.getPaintProperty(layerId, 'heatmap-color') as InterpolateType[];
 
 		if (!value) {
 			value = [
@@ -66,7 +64,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'heatmap-color', value);
+		map.setPaintProperty(layerId, 'heatmap-color', value);
 	};
 
 	const handleColorChanged = debounce((index: number) => {

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapColor.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import chroma from 'chroma-js';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
-	import { debounce } from 'lodash-es';
+	import type { createMapStore } from '$lib/stores';
 	import ColorPicker from '$lib/util/ColorPicker.svelte';
+	import chroma from 'chroma-js';
+	import { debounce } from 'lodash-es';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	type InterpolateType = number | string[] | string;
@@ -14,7 +17,7 @@
 	const START_POSITION = 3;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'heatmap-color') as InterpolateType[];
+		let value = $map.getPaintProperty(layer.id, 'heatmap-color') as InterpolateType[];
 
 		if (!value) {
 			value = [
@@ -63,7 +66,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'heatmap-color', value);
+		map.setPaintProperty(layer.id, 'heatmap-color', value);
 	};
 
 	const handleColorChanged = debounce((index: number) => {

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type {
 		HeatmapLayerSpecification,
 		LineLayerSpecification,
 		SymbolLayerSpecification
 	} from 'maplibre-gl';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	let heatmapLayerId = `${layerId} heatmap`;
 	let isHeatmapCreated = $map.getLayer(heatmapLayerId) ? true : false;

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type {
 		HeatmapLayerSpecification,
 		LineLayerSpecification,
@@ -7,7 +7,7 @@
 	} from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	let heatmapLayerId = `${layerId} heatmap`;

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import type {
-		Map,
 		HeatmapLayerSpecification,
-		SymbolLayerSpecification,
-		LayerSpecification
+		LayerSpecification,
+		SymbolLayerSpecification
 	} from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 	let heatmapLayerId = `${layer.id} heatmap`;
-	let isHeatmapCreated = map.getLayer(heatmapLayerId) ? true : false;
+	let isHeatmapCreated = $map.getLayer(heatmapLayerId) ? true : false;
 
 	$: if (isHeatmapCreated === true) {
 		createHeatmap();
@@ -20,7 +22,7 @@
 	}
 
 	const createHeatmap = () => {
-		if (map.getLayer(heatmapLayerId)) return;
+		if ($map.getLayer(heatmapLayerId)) return;
 
 		const symbolLayer: SymbolLayerSpecification = layer as SymbolLayerSpecification;
 
@@ -59,12 +61,12 @@
 		heatmapLayer.minzoom = symbolLayer.maxzoom ?? 0;
 		heatmapLayer.maxzoom = symbolLayer.maxzoom ?? 24;
 
-		map.addLayer(heatmapLayer, symbolLayer.id);
+		$map.addLayer(heatmapLayer, symbolLayer.id);
 	};
 
 	const deleteHeatmap = () => {
-		if (map.getLayer(heatmapLayerId)) {
-			map.removeLayer(heatmapLayerId);
+		if ($map.getLayer(heatmapLayerId)) {
+			$map.removeLayer(heatmapLayerId);
 		}
 	};
 </script>

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapGenerator.svelte
@@ -2,15 +2,15 @@
 	import type { createMapStore } from '$lib/stores';
 	import type {
 		HeatmapLayerSpecification,
-		LayerSpecification,
+		LineLayerSpecification,
 		SymbolLayerSpecification
 	} from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
+	let layerId: string = getContext('layerId');
 
-	export let layer: LayerSpecification;
-	let heatmapLayerId = `${layer.id} heatmap`;
+	let heatmapLayerId = `${layerId} heatmap`;
 	let isHeatmapCreated = $map.getLayer(heatmapLayerId) ? true : false;
 
 	$: if (isHeatmapCreated === true) {
@@ -23,8 +23,10 @@
 
 	const createHeatmap = () => {
 		if ($map.getLayer(heatmapLayerId)) return;
-
-		const symbolLayer: SymbolLayerSpecification = layer as SymbolLayerSpecification;
+		const layer = $map.getStyle().layers.find((l) => l.id === layerId);
+		const symbolLayer: SymbolLayerSpecification | LineLayerSpecification = layer as
+			| SymbolLayerSpecification
+			| LineLayerSpecification;
 
 		const heatmapLayer: HeatmapLayerSpecification = {
 			id: heatmapLayerId,

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'heatmap-intensity');

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'heatmap-intensity');
+		let value = $map.getPaintProperty(layer.id, 'heatmap-intensity');
 
 		if (!value) {
 			value = 1;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'heatmap-intensity', value);
+		map.setPaintProperty(layer.id, 'heatmap-intensity', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapIntensity.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'heatmap-intensity');
+		let value = $map.getPaintProperty(layerId, 'heatmap-intensity');
 
 		if (!value) {
 			value = 1;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'heatmap-intensity', value);
+		map.setPaintProperty(layerId, 'heatmap-intensity', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'heatmap-radius');
+		let value = $map.getPaintProperty(layer.id, 'heatmap-radius');
 
 		if (!value) {
 			value = 30;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'heatmap-radius', value);
+		map.setPaintProperty(layer.id, 'heatmap-radius', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'heatmap-radius');

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'heatmap-radius');
+		let value = $map.getPaintProperty(layerId, 'heatmap-radius');
 
 		if (!value) {
 			value = 30;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'heatmap-radius', value);
+		map.setPaintProperty(layerId, 'heatmap-radius', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapRadius.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'heatmap-weight');
+		let value = $map.getPaintProperty(layer.id, 'heatmap-weight');
 
 		if (!value) {
 			value = 30;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'heatmap-weight', value);
+		map.setPaintProperty(layer.id, 'heatmap-weight', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'heatmap-weight');

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'heatmap-weight');
+		let value = $map.getPaintProperty(layerId, 'heatmap-weight');
 
 		if (!value) {
 			value = 30;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'heatmap-weight', value);
+		map.setPaintProperty(layerId, 'heatmap-weight', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
+++ b/packages/legend/src/lib/editor-controls/heatmap/HeatmapWeight.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'hillshade-exaggeration');
+		let value = $map.getPaintProperty(layerId, 'hillshade-exaggeration');
 
 		if (!value) {
 			value = 0.5;
@@ -21,7 +19,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'hillshade-exaggeration', value);
+		map.setPaintProperty(layerId, 'hillshade-exaggeration', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'hillshade-exaggeration');
+		let value = $map.getPaintProperty(layer.id, 'hillshade-exaggeration');
 
 		if (!value) {
 			value = 0.5;
@@ -18,7 +21,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'hillshade-exaggeration', value);
+		map.setPaintProperty(layer.id, 'hillshade-exaggeration', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeExaggeration.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'hillshade-exaggeration');

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'hillshade-illumination-direction');

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'hillshade-illumination-direction');
+		let value = $map.getPaintProperty(layerId, 'hillshade-illumination-direction');
 
 		if (!value) {
 			value = 335;
@@ -21,7 +19,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'hillshade-illumination-direction', value);
+		map.setPaintProperty(layerId, 'hillshade-illumination-direction', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'hillshade-illumination-direction');
+		let value = $map.getPaintProperty(layer.id, 'hillshade-illumination-direction');
 
 		if (!value) {
 			value = 335;
@@ -18,7 +21,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'hillshade-illumination-direction', value);
+		map.setPaintProperty(layer.id, 'hillshade-illumination-direction', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
+++ b/packages/legend/src/lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'line-blur');

--- a/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'line-blur');
+		let value = $map.getPaintProperty(layer.id, 'line-blur');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'line-blur', value);
+		map.setPaintProperty(layer.id, 'line-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineBlur.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'line-blur');
+		let value = $map.getPaintProperty(layerId, 'line-blur');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'line-blur', value);
+		map.setPaintProperty(layerId, 'line-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
-	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [

--- a/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
@@ -2,12 +2,10 @@
 	import type { Option } from '$lib/interfaces';
 	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [
 		{
@@ -29,7 +27,7 @@
 	];
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'line-dasharray');
+		let value = $map.getPaintProperty(layerId, 'line-dasharray');
 
 		if (!value) {
 			value = options[0].value;
@@ -43,13 +41,9 @@
 
 	const setValue = () => {
 		if (value) {
-			map.setPaintProperty(layer.id, 'line-dasharray', value);
+			map.setPaintProperty(layerId, 'line-dasharray', value);
 		} else {
-			map.setPaintProperty(layer.id, 'line-dasharray', undefined);
-		}
-		const newLayer = $map.getStyle().layers.find((l) => l.id === layer.id);
-		if (newLayer) {
-			layer = newLayer;
+			map.setPaintProperty(layerId, 'line-dasharray', undefined);
 		}
 	};
 </script>

--- a/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import type { Option } from '$lib/interfaces';
+	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	let options: Option[] = [
@@ -26,7 +29,7 @@
 	];
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'line-dasharray');
+		let value = $map.getPaintProperty(layer.id, 'line-dasharray');
 
 		if (!value) {
 			value = options[0].value;
@@ -40,11 +43,11 @@
 
 	const setValue = () => {
 		if (value) {
-			map?.setPaintProperty(layer.id, 'line-dasharray', value);
+			map.setPaintProperty(layer.id, 'line-dasharray', value);
 		} else {
-			map?.setPaintProperty(layer.id, 'line-dasharray', undefined);
+			map.setPaintProperty(layer.id, 'line-dasharray', undefined);
 		}
-		const newLayer = map.getStyle().layers.find((l) => l.id === layer.id);
+		const newLayer = $map.getStyle().layers.find((l) => l.id === layer.id);
 		if (newLayer) {
 			layer = newLayer;
 		}

--- a/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineDashArray.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
 	import Options from '$lib/util/Options.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	let options: Option[] = [
 		{

--- a/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'line-width');

--- a/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'line-width');
+		let value = $map.getPaintProperty(layerId, 'line-width');
 
 		if (!value) {
 			value = 1;
@@ -23,7 +21,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map.setPaintProperty(layer.id, 'line-width', value);
+		map.setPaintProperty(layerId, 'line-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/line/LineWidth.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'line-width');
+		let value = $map.getPaintProperty(layer.id, 'line-width');
 
 		if (!value) {
 			value = 1;
@@ -20,7 +23,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map?.setPaintProperty(layer.id, 'line-width', value);
+		map.setPaintProperty(layer.id, 'line-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-brightness-max');
+		let value = $map.getPaintProperty(layerId, 'raster-brightness-max');
 
 		if (!value) {
 			value = 1;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-brightness-max', value);
+		map.setPaintProperty(layerId, 'raster-brightness-max', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'raster-brightness-max');

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-brightness-max');
+		let value = $map.getPaintProperty(layer.id, 'raster-brightness-max');
 
 		if (!value) {
 			value = 1;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-brightness-max', value);
+		map.setPaintProperty(layer.id, 'raster-brightness-max', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMax.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'raster-brightness-min');

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-brightness-min');
+		let value = $map.getPaintProperty(layerId, 'raster-brightness-min');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-brightness-min', value);
+		map.setPaintProperty(layerId, 'raster-brightness-min', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterBrightnessMin.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-brightness-min');
+		let value = $map.getPaintProperty(layer.id, 'raster-brightness-min');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-brightness-min', value);
+		map.setPaintProperty(layer.id, 'raster-brightness-min', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-contrast');
+		let value = $map.getPaintProperty(layer.id, 'raster-contrast');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-contrast', value);
+		map.setPaintProperty(layer.id, 'raster-contrast', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'raster-contrast');

--- a/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-contrast');
+		let value = $map.getPaintProperty(layerId, 'raster-contrast');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-contrast', value);
+		map.setPaintProperty(layerId, 'raster-contrast', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterContrast.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-hue-rotate');
+		let value = $map.getPaintProperty(layer.id, 'raster-hue-rotate');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-hue-rotate', value);
+		map.setPaintProperty(layer.id, 'raster-hue-rotate', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-hue-rotate');
+		let value = $map.getPaintProperty(layerId, 'raster-hue-rotate');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-hue-rotate', value);
+		map.setPaintProperty(layerId, 'raster-hue-rotate', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterHueRotate.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'raster-hue-rotate');

--- a/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
-	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [

--- a/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
 	import Options from '$lib/util/Options.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	let options: Option[] = [
 		{

--- a/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
@@ -2,12 +2,10 @@
 	import type { Option } from '$lib/interfaces';
 	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [
 		{
@@ -21,7 +19,7 @@
 	];
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-resampling');
+		let value = $map.getPaintProperty(layerId, 'raster-resampling');
 
 		if (!value) {
 			value = options[0].value;
@@ -34,7 +32,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-resampling', value);
+		map.setPaintProperty(layerId, 'raster-resampling', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterResampling.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import type { Option } from '$lib/interfaces';
+	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	let options: Option[] = [
@@ -18,7 +21,7 @@
 	];
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-resampling');
+		let value = $map.getPaintProperty(layer.id, 'raster-resampling');
 
 		if (!value) {
 			value = options[0].value;
@@ -31,7 +34,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-resampling', value);
+		map.setPaintProperty(layer.id, 'raster-resampling', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'raster-saturation');

--- a/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'raster-saturation');
+		let value = $map.getPaintProperty(layerId, 'raster-saturation');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'raster-saturation', value);
+		map.setPaintProperty(layerId, 'raster-saturation', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'raster-saturation');
+		let value = $map.getPaintProperty(layer.id, 'raster-saturation');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'raster-saturation', value);
+		map.setPaintProperty(layer.id, 'raster-saturation', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
+++ b/packages/legend/src/lib/editor-controls/raster/RasterSaturation.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'icon-halo-blur');
+		let value = $map.getPaintProperty(layer.id, 'icon-halo-blur');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'icon-halo-blur', value);
+		map.setPaintProperty(layer.id, 'icon-halo-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'icon-halo-blur');

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloBlur.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'icon-halo-blur');
+		let value = $map.getPaintProperty(layerId, 'icon-halo-blur');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'icon-halo-blur', value);
+		map.setPaintProperty(layerId, 'icon-halo-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'icon-halo-width');
+		let value = $map.getPaintProperty(layerId, 'icon-halo-width');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'icon-halo-width', value);
+		map.setPaintProperty(layerId, 'icon-halo-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'icon-halo-width');
+		let value = $map.getPaintProperty(layer.id, 'icon-halo-width');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'icon-halo-width', value);
+		map.setPaintProperty(layer.id, 'icon-halo-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconHaloWidth.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'icon-halo-width');

--- a/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
-	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [

--- a/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
 	import Options from '$lib/util/Options.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	let options: Option[] = [
 		{

--- a/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
@@ -2,12 +2,10 @@
 	import type { Option } from '$lib/interfaces';
 	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	let options: Option[] = [
 		{
@@ -25,7 +23,7 @@
 	];
 
 	const getValue = () => {
-		let value = $map.getLayoutProperty(layer.id, 'icon-overlap');
+		let value = $map.getLayoutProperty(layerId, 'icon-overlap');
 
 		if (!value) {
 			value = options[0].value;
@@ -38,7 +36,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setLayoutProperty(layer.id, 'icon-overlap', value);
+		map.setLayoutProperty(layerId, 'icon-overlap', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconOverlap.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import type { Option } from '$lib/interfaces';
+	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	let options: Option[] = [
@@ -22,7 +25,7 @@
 	];
 
 	const getValue = () => {
-		let value = map.getLayoutProperty(layer.id, 'icon-overlap');
+		let value = $map.getLayoutProperty(layer.id, 'icon-overlap');
 
 		if (!value) {
 			value = options[0].value;
@@ -35,7 +38,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setLayoutProperty(layer.id, 'icon-overlap', value);
+		map.setLayoutProperty(layer.id, 'icon-overlap', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getLayoutProperty(layerId, 'icon-size');

--- a/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getLayoutProperty(layer.id, 'icon-size');
+		let value = $map.getLayoutProperty(layer.id, 'icon-size');
 
 		if (!value) {
 			value = 1;
@@ -20,7 +23,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map?.setLayoutProperty(layer.id, 'icon-size', value);
+		map.setLayoutProperty(layer.id, 'icon-size', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getLayoutProperty(layer.id, 'icon-size');
+		let value = $map.getLayoutProperty(layerId, 'icon-size');
 
 		if (!value) {
 			value = 1;
@@ -23,7 +21,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map.setLayoutProperty(layer.id, 'icon-size', value);
+		map.setLayoutProperty(layerId, 'icon-size', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/IconSize.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'text-halo-blur');
+		let value = $map.getPaintProperty(layerId, 'text-halo-blur');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'text-halo-blur', value);
+		map.setPaintProperty(layerId, 'text-halo-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'text-halo-blur');

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloBlur.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'text-halo-blur');
+		let value = $map.getPaintProperty(layer.id, 'text-halo-blur');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'text-halo-blur', value);
+		map.setPaintProperty(layer.id, 'text-halo-blur', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layer.id, 'text-halo-width');
+		let value = $map.getPaintProperty(layer.id, 'text-halo-width');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layer.id, 'text-halo-width', value);
+		map.setPaintProperty(layer.id, 'text-halo-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getPaintProperty(layer.id, 'text-halo-width');
+		let value = $map.getPaintProperty(layerId, 'text-halo-width');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setPaintProperty(layer.id, 'text-halo-width', value);
+		map.setPaintProperty(layerId, 'text-halo-width', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextHaloWidth.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getPaintProperty(layerId, 'text-halo-width');

--- a/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getLayoutProperty(layer.id, 'text-rotate');
+		let value = $map.getLayoutProperty(layerId, 'text-rotate');
 
 		if (!value) {
 			value = 0;
@@ -22,7 +20,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map.setLayoutProperty(layer.id, 'text-rotate', value);
+		map.setLayoutProperty(layerId, 'text-rotate', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getLayoutProperty(layer.id, 'text-rotate');
+		let value = $map.getLayoutProperty(layer.id, 'text-rotate');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +22,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setLayoutProperty(layer.id, 'text-rotate', value);
+		map.setLayoutProperty(layer.id, 'text-rotate', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextRotate.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getLayoutProperty(layerId, 'text-rotate');

--- a/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { Map, LayerSpecification } from 'maplibre-gl';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	const getValue = () => {
-		let value = map.getLayoutProperty(layer.id, 'text-size');
+		let value = $map.getLayoutProperty(layer.id, 'text-size');
 
 		if (!value) {
 			value = 16;
@@ -20,7 +23,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map?.setLayoutProperty(layer.id, 'text-size', value);
+		map.setLayoutProperty(layer.id, 'text-size', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
-	import { getContext } from 'svelte';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
 	const getValue = () => {
 		let value = $map.getLayoutProperty(layerId, 'text-size');

--- a/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import type { createMapStore } from '$lib/stores';
 	import Slider from '$lib/util/Slider.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
 
 	const getValue = () => {
-		let value = $map.getLayoutProperty(layer.id, 'text-size');
+		let value = $map.getLayoutProperty(layerId, 'text-size');
 
 		if (!value) {
 			value = 16;
@@ -23,7 +21,7 @@
 
 	const setValue = () => {
 		if (!value) return;
-		map.setLayoutProperty(layer.id, 'text-size', value);
+		map.setLayoutProperty(layerId, 'text-size', value);
 	};
 </script>
 

--- a/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
+++ b/packages/legend/src/lib/editor-controls/symbol/TextSize.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { createMapStore } from '$lib/stores';
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import Slider from '$lib/util/Slider.svelte';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	const getValue = () => {

--- a/packages/legend/src/lib/editor-panels/BackgroundEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/BackgroundEditor.svelte
@@ -2,21 +2,18 @@
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'background', property: 'background-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Background color"
 	help={{ type: 'paint', layerType: 'background', property: 'background-color' }}
 >
-	<ColorControl bind:layer propertyName="background-color" />
+	<ColorControl propertyName="background-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/BackgroundEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/BackgroundEditor.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
@@ -12,12 +11,12 @@
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'background', property: 'background-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Background color"
 	help={{ type: 'paint', layerType: 'background', property: 'background-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="background-color" />
+	<ColorControl bind:layer propertyName="background-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/CircleEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/CircleEditor.svelte
@@ -1,51 +1,50 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import CircleRadius from '$lib/editor-controls/circle/CircleRadius.svelte';
 	import CircleStrokeWidth from '$lib/editor-controls/circle/CircleStrokeWidth.svelte';
-	import FieldControl from '$lib/util/FieldControl.svelte';
 	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
+	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:map bind:layer />
+	<HeatmapGenerator bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Circle radius"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-radius' }}
 >
-	<CircleRadius bind:map bind:layer />
+	<CircleRadius bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Circle color"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="circle-color" />
+	<ColorControl bind:layer propertyName="circle-color" />
 </FieldControl>
 
 <FieldControl
 	title="Circle stroke width"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-stroke-width' }}
 >
-	<CircleStrokeWidth bind:map bind:layer />
+	<CircleStrokeWidth bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Circle stroke color"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-stroke-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="circle-stroke-color" />
+	<ColorControl bind:layer propertyName="circle-stroke-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/CircleEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/CircleEditor.svelte
@@ -5,46 +5,43 @@
 	import CircleStrokeWidth from '$lib/editor-controls/circle/CircleStrokeWidth.svelte';
 	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:layer />
+	<HeatmapGenerator />
 </FieldControl>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Circle radius"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-radius' }}
 >
-	<CircleRadius bind:layer />
+	<CircleRadius />
 </FieldControl>
 
 <FieldControl
 	title="Circle color"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-color' }}
 >
-	<ColorControl bind:layer propertyName="circle-color" />
+	<ColorControl propertyName="circle-color" />
 </FieldControl>
 
 <FieldControl
 	title="Circle stroke width"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-stroke-width' }}
 >
-	<CircleStrokeWidth bind:layer />
+	<CircleStrokeWidth />
 </FieldControl>
 
 <FieldControl
 	title="Circle stroke color"
 	help={{ type: 'paint', layerType: 'circle', property: 'circle-stroke-color' }}
 >
-	<ColorControl bind:layer propertyName="circle-stroke-color" />
+	<ColorControl propertyName="circle-stroke-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/FillEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/FillEditor.svelte
@@ -1,27 +1,26 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Opacity" help={{ type: 'paint', layerType: 'fill', property: 'fill-opacity' }}>
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Fill color"
 	help={{ type: 'paint', layerType: 'fill', property: 'fill-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="fill-color" />
+	<ColorControl bind:layer propertyName="fill-color" />
 </FieldControl>
 
 <FieldControl
 	title="Fill outline color"
 	help={{ type: 'paint', layerType: 'fill', property: 'fill-outline-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="fill-outline-color" />
+	<ColorControl bind:layer propertyName="fill-outline-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/FillEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/FillEditor.svelte
@@ -2,25 +2,22 @@
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Opacity" help={{ type: 'paint', layerType: 'fill', property: 'fill-opacity' }}>
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Fill color"
 	help={{ type: 'paint', layerType: 'fill', property: 'fill-color' }}
 >
-	<ColorControl bind:layer propertyName="fill-color" />
+	<ColorControl propertyName="fill-color" />
 </FieldControl>
 
 <FieldControl
 	title="Fill outline color"
 	help={{ type: 'paint', layerType: 'fill', property: 'fill-outline-color' }}
 >
-	<ColorControl bind:layer propertyName="fill-outline-color" />
+	<ColorControl propertyName="fill-outline-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/FillExtrusionEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/FillExtrusionEditor.svelte
@@ -4,35 +4,32 @@
 	import FillExtrusionBase from '$lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte';
 	import FillExtrusionHeight from '$lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion color"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-color' }}
 >
-	<ColorControl bind:layer propertyName="fill-extrusion-color" />
+	<ColorControl propertyName="fill-extrusion-color" />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion height"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-height' }}
 >
-	<FillExtrusionHeight bind:layer />
+	<FillExtrusionHeight />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion base"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-base' }}
 >
-	<FillExtrusionBase bind:layer />
+	<FillExtrusionBase />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/FillExtrusionEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/FillExtrusionEditor.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
-	import FillExtrusionHeight from '$lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import FillExtrusionBase from '$lib/editor-controls/fill-extrusion/FillExtrusionBase.svelte';
+	import FillExtrusionHeight from '$lib/editor-controls/fill-extrusion/FillExtrusionHeight.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
@@ -14,26 +13,26 @@
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion color"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="fill-extrusion-color" />
+	<ColorControl bind:layer propertyName="fill-extrusion-color" />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion height"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-height' }}
 >
-	<FillExtrusionHeight bind:map bind:layer />
+	<FillExtrusionHeight bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Fill extrusion base"
 	help={{ type: 'paint', layerType: 'fill-extrusion', property: 'fill-extrusion-base' }}
 >
-	<FillExtrusionBase bind:map bind:layer />
+	<FillExtrusionBase bind:layer />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/HeatmapEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/HeatmapEditor.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
-	import FieldControl from '$lib/util/FieldControl.svelte';
+	import HeatmapColor from '$lib/editor-controls/heatmap/HeatmapColor.svelte';
 	import HeatmapIntensity from '$lib/editor-controls/heatmap/HeatmapIntensity.svelte';
 	import HeatmapRadius from '$lib/editor-controls/heatmap/HeatmapRadius.svelte';
 	import HeatmapWeight from '$lib/editor-controls/heatmap/HeatmapWeight.svelte';
-	import HeatmapColor from '$lib/editor-controls/heatmap/HeatmapColor.svelte';
+	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
@@ -15,33 +14,33 @@
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap color"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-color' }}
 >
-	<HeatmapColor bind:map bind:layer />
+	<HeatmapColor bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap intensity"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-intensity' }}
 >
-	<HeatmapIntensity bind:map bind:layer />
+	<HeatmapIntensity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap radius"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-radius' }}
 >
-	<HeatmapRadius bind:map bind:layer />
+	<HeatmapRadius bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap weight"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-weight' }}
 >
-	<HeatmapWeight bind:map bind:layer />
+	<HeatmapWeight bind:layer />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/HeatmapEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/HeatmapEditor.svelte
@@ -5,42 +5,39 @@
 	import HeatmapRadius from '$lib/editor-controls/heatmap/HeatmapRadius.svelte';
 	import HeatmapWeight from '$lib/editor-controls/heatmap/HeatmapWeight.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap color"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-color' }}
 >
-	<HeatmapColor bind:layer />
+	<HeatmapColor />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap intensity"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-intensity' }}
 >
-	<HeatmapIntensity bind:layer />
+	<HeatmapIntensity />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap radius"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-radius' }}
 >
-	<HeatmapRadius bind:layer />
+	<HeatmapRadius />
 </FieldControl>
 
 <FieldControl
 	title="Heatmap weight"
 	help={{ type: 'paint', layerType: 'heatmap', property: 'heatmap-weight' }}
 >
-	<HeatmapWeight bind:layer />
+	<HeatmapWeight />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/HillshadeEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/HillshadeEditor.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
 	import HillshadeExaggeration from '$lib/editor-controls/hillshade/HillshadeExaggeration.svelte';
 	import HillshadeIlluminationDirection from '$lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
@@ -13,33 +12,33 @@
 	title="Hillshade exaggeration"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-exaggeration' }}
 >
-	<HillshadeExaggeration bind:map bind:layer />
+	<HillshadeExaggeration bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade accent color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-accent-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="hillshade-accent-color" />
+	<ColorControl bind:layer propertyName="hillshade-accent-color" />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade highlight color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-highlight-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="hillshade-highlight-color" />
+	<ColorControl bind:layer propertyName="hillshade-highlight-color" />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade illumination direction"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-illumination-direction' }}
 >
-	<HillshadeIlluminationDirection bind:map bind:layer />
+	<HillshadeIlluminationDirection bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade shadow color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-shadow-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="hillshade-shadow-color" />
+	<ColorControl bind:layer propertyName="hillshade-shadow-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/HillshadeEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/HillshadeEditor.svelte
@@ -3,42 +3,39 @@
 	import HillshadeExaggeration from '$lib/editor-controls/hillshade/HillshadeExaggeration.svelte';
 	import HillshadeIlluminationDirection from '$lib/editor-controls/hillshade/HillshadeIlluminationDirection.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl
 	title="Hillshade exaggeration"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-exaggeration' }}
 >
-	<HillshadeExaggeration bind:layer />
+	<HillshadeExaggeration />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade accent color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-accent-color' }}
 >
-	<ColorControl bind:layer propertyName="hillshade-accent-color" />
+	<ColorControl propertyName="hillshade-accent-color" />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade highlight color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-highlight-color' }}
 >
-	<ColorControl bind:layer propertyName="hillshade-highlight-color" />
+	<ColorControl propertyName="hillshade-highlight-color" />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade illumination direction"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-illumination-direction' }}
 >
-	<HillshadeIlluminationDirection bind:layer />
+	<HillshadeIlluminationDirection />
 </FieldControl>
 
 <FieldControl
 	title="Hillshade shadow color"
 	help={{ type: 'paint', layerType: 'hillshade', property: 'hillshade-shadow-color' }}
 >
-	<ColorControl bind:layer propertyName="hillshade-shadow-color" />
+	<ColorControl propertyName="hillshade-shadow-color" />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/LineEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/LineEditor.svelte
@@ -6,40 +6,37 @@
 	import LineDashArray from '$lib/editor-controls/line/LineDashArray.svelte';
 	import LineWidth from '$lib/editor-controls/line/LineWidth.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:layer />
+	<HeatmapGenerator />
 </FieldControl>
 
 <FieldControl title="Opacity" help={{ type: 'paint', layerType: 'line', property: 'line-opacity' }}>
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Line color"
 	help={{ type: 'paint', layerType: 'line', property: 'line-color' }}
 >
-	<ColorControl bind:layer propertyName="line-color" />
+	<ColorControl propertyName="line-color" />
 </FieldControl>
 
 <FieldControl
 	title="Line width"
 	help={{ type: 'paint', layerType: 'line', property: 'line-width' }}
 >
-	<LineWidth bind:layer />
+	<LineWidth />
 </FieldControl>
 
 <FieldControl
 	title="Line pattern"
 	help={{ type: 'paint', layerType: 'line', property: 'line-dasharray' }}
 >
-	<LineDashArray bind:layer />
+	<LineDashArray />
 </FieldControl>
 
 <FieldControl title="Line blur" help={{ type: 'paint', layerType: 'line', property: 'line-blur' }}>
-	<LineBlur bind:layer />
+	<LineBlur />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/LineEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/LineEditor.svelte
@@ -1,46 +1,45 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
-	import LineWidth from '$lib/editor-controls/line/LineWidth.svelte';
-	import FieldControl from '$lib/util/FieldControl.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
+	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
 	import LineBlur from '$lib/editor-controls/line/LineBlur.svelte';
 	import LineDashArray from '$lib/editor-controls/line/LineDashArray.svelte';
-	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
+	import LineWidth from '$lib/editor-controls/line/LineWidth.svelte';
+	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:map bind:layer />
+	<HeatmapGenerator bind:layer />
 </FieldControl>
 
 <FieldControl title="Opacity" help={{ type: 'paint', layerType: 'line', property: 'line-opacity' }}>
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Line color"
 	help={{ type: 'paint', layerType: 'line', property: 'line-color' }}
 >
-	<ColorControl bind:map bind:layer propertyName="line-color" />
+	<ColorControl bind:layer propertyName="line-color" />
 </FieldControl>
 
 <FieldControl
 	title="Line width"
 	help={{ type: 'paint', layerType: 'line', property: 'line-width' }}
 >
-	<LineWidth bind:map bind:layer />
+	<LineWidth bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Line pattern"
 	help={{ type: 'paint', layerType: 'line', property: 'line-dasharray' }}
 >
-	<LineDashArray bind:map bind:layer />
+	<LineDashArray bind:layer />
 </FieldControl>
 
 <FieldControl title="Line blur" help={{ type: 'paint', layerType: 'line', property: 'line-blur' }}>
-	<LineBlur bind:map bind:layer />
+	<LineBlur bind:layer />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/ManualEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/ManualEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
-	import type { createMapStore } from '$lib/stores';
 	import Options from '$lib/util/Options.svelte';
 	import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons';
 	import yaml from 'js-yaml';
@@ -8,7 +8,7 @@
 	import { getContext, onMount } from 'svelte';
 	import Fa from 'svelte-fa';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 	let layer: LayerSpecification = $map
 		.getStyle()

--- a/packages/legend/src/lib/editor-panels/ManualEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/ManualEditor.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Fa from 'svelte-fa';
+	import type { Option } from '$lib/interfaces';
+	import type { createMapStore } from '$lib/stores';
+	import Options from '$lib/util/Options.svelte';
 	import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons';
 	import yaml from 'js-yaml';
-	import Options from '$lib/util/Options.svelte';
-	import type { Option } from '$lib/interfaces';
-	import { onMount } from 'svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext, onMount } from 'svelte';
+	import Fa from 'svelte-fa';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 
 	let formatOptions: Option[] = [

--- a/packages/legend/src/lib/editor-panels/ManualEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/ManualEditor.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import type { Option } from '$lib/interfaces';
 	import Options from '$lib/util/Options.svelte';
 	import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons';
 	import yaml from 'js-yaml';
 	import type { LayerSpecification } from 'maplibre-gl';
-	import { getContext, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import Fa from 'svelte-fa';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 	let layer: LayerSpecification = $map
 		.getStyle()
-		.layers.find((l) => l.id === layerId) as LayerSpecification;
+		.layers.find((l: LayerSpecification) => l.id === layerId) as LayerSpecification;
 
 	let formatOptions: Option[] = [
 		{

--- a/packages/legend/src/lib/editor-panels/ManualEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/ManualEditor.svelte
@@ -9,8 +9,10 @@
 	import Fa from 'svelte-fa';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
-
-	export let layer: LayerSpecification;
+	let layerId: string = getContext('layerId');
+	let layer: LayerSpecification = $map
+		.getStyle()
+		.layers.find((l) => l.id === layerId) as LayerSpecification;
 
 	let formatOptions: Option[] = [
 		{

--- a/packages/legend/src/lib/editor-panels/RasterEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/RasterEditor.svelte
@@ -7,56 +7,53 @@
 	import RasterResampling from '$lib/editor-controls/raster/RasterResampling.svelte';
 	import RasterSaturation from '$lib/editor-controls/raster/RasterSaturation.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
-
-	export let layer: LayerSpecification;
 </script>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 <FieldControl
 	title="Raster brightness max"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-brightness-max' }}
 >
-	<RasterBrightnessMax bind:layer />
+	<RasterBrightnessMax />
 </FieldControl>
 
 <FieldControl
 	title="Raster brightness min"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-brightness-min' }}
 >
-	<RasterBrightnessMin bind:layer />
+	<RasterBrightnessMin />
 </FieldControl>
 
 <FieldControl
 	title="Raster contrast"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-contrast' }}
 >
-	<RasterContrast bind:layer />
+	<RasterContrast />
 </FieldControl>
 
 <FieldControl
 	title="Raster hue rotate"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-hue-rotate' }}
 >
-	<RasterHueRotate bind:layer />
+	<RasterHueRotate />
 </FieldControl>
 
 <FieldControl
 	title="Raster resampling"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-resampling' }}
 >
-	<RasterResampling bind:layer />
+	<RasterResampling />
 </FieldControl>
 
 <FieldControl
 	title="Raster saturation"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-saturation' }}
 >
-	<RasterSaturation bind:layer />
+	<RasterSaturation />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/RasterEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/RasterEditor.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import RasterBrightnessMax from '$lib/editor-controls/raster/RasterBrightnessMax.svelte';
 	import RasterBrightnessMin from '$lib/editor-controls/raster/RasterBrightnessMin.svelte';
 	import RasterContrast from '$lib/editor-controls/raster/RasterContrast.svelte';
 	import RasterHueRotate from '$lib/editor-controls/raster/RasterHueRotate.svelte';
+	import RasterResampling from '$lib/editor-controls/raster/RasterResampling.svelte';
 	import RasterSaturation from '$lib/editor-controls/raster/RasterSaturation.svelte';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import RasterResampling from '$lib/editor-controls/raster/RasterResampling.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
 
-	export let map: Map;
 	export let layer: LayerSpecification;
 </script>
 
@@ -17,47 +16,47 @@
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster brightness max"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-brightness-max' }}
 >
-	<RasterBrightnessMax bind:map bind:layer />
+	<RasterBrightnessMax bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster brightness min"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-brightness-min' }}
 >
-	<RasterBrightnessMin bind:map bind:layer />
+	<RasterBrightnessMin bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster contrast"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-contrast' }}
 >
-	<RasterContrast bind:map bind:layer />
+	<RasterContrast bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster hue rotate"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-hue-rotate' }}
 >
-	<RasterHueRotate bind:map bind:layer />
+	<RasterHueRotate bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster resampling"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-resampling' }}
 >
-	<RasterResampling bind:map bind:layer />
+	<RasterResampling bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Raster saturation"
 	help={{ type: 'paint', layerType: 'raster', property: 'raster-saturation' }}
 >
-	<RasterSaturation bind:map bind:layer />
+	<RasterSaturation bind:layer />
 </FieldControl>

--- a/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
@@ -13,27 +13,30 @@
 	import type SpriteLoader from '$lib/sprite';
 	import type { createMapStore } from '$lib/stores';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { LayerSpecification } from 'maplibre-gl';
+	import type { SymbolLayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
 	let map: ReturnType<typeof createMapStore> = getContext('map');
+	let layerId: string = getContext('layerId');
 
-	export let layer: LayerSpecification;
+	let layer: SymbolLayerSpecification = $map.getStyle().layers.find((l) => {
+		l.id === layerId;
+	}) as SymbolLayerSpecification;
 	export let spriteLoader: SpriteLoader;
 
-	let iconImage = $map.getLayoutProperty(layer.id, 'icon-image');
-	let textField = $map.getLayoutProperty(layer.id, 'text-field');
+	let iconImage = $map.getLayoutProperty(layerId, 'icon-image');
+	let textField = $map.getLayoutProperty(layerId, 'text-field');
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:layer />
+	<HeatmapGenerator />
 </FieldControl>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'symbol', property: 'icon-opacity' }}
 >
-	<Opacity bind:layer />
+	<Opacity />
 </FieldControl>
 
 {#if iconImage}
@@ -41,43 +44,43 @@
 		title="Icon size"
 		help={{ type: 'layout', layerType: 'symbol', property: 'icon-size' }}
 	>
-		<IconSize bind:layer />
+		<IconSize />
 	</FieldControl>
 
 	<FieldControl
 		title="Icon overlap"
 		help={{ type: 'layout', layerType: 'symbol', property: 'icon-overlap' }}
 	>
-		<IconOverlap bind:layer />
+		<IconOverlap />
 	</FieldControl>
 
-	{#if spriteLoader?.isSdf(layer)}
+	{#if layer && spriteLoader?.isSdf(layer)}
 		<FieldControl
 			title="Icon color"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-color' }}
 		>
-			<ColorControl bind:layer propertyName="icon-color" />
+			<ColorControl propertyName="icon-color" />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo color"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-color' }}
 		>
-			<ColorControl bind:layer propertyName="icon-halo-color" />
+			<ColorControl propertyName="icon-halo-color" />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo width"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-width' }}
 		>
-			<IconHaloWidth bind:layer />
+			<IconHaloWidth />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo blur"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-blur' }}
 		>
-			<IconHaloBlur bind:layer />
+			<IconHaloBlur />
 		</FieldControl>
 	{/if}
 {/if}
@@ -87,41 +90,41 @@
 		title="Text size"
 		help={{ type: 'layout', layerType: 'symbol', property: 'text-size' }}
 	>
-		<TextSize bind:layer />
+		<TextSize />
 	</FieldControl>
 
 	<FieldControl
 		title="Text color"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-color' }}
 	>
-		<ColorControl bind:layer propertyName="text-color" />
+		<ColorControl propertyName="text-color" />
 	</FieldControl>
 
 	<FieldControl
 		title="Text rotate"
 		help={{ type: 'layout', layerType: 'symbol', property: 'text-rotate' }}
 	>
-		<TextRotate bind:layer />
+		<TextRotate />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo color"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-color' }}
 	>
-		<ColorControl bind:layer propertyName="text-halo-color" />
+		<ColorControl propertyName="text-halo-color" />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo width"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-width' }}
 	>
-		<TextHaloWidth bind:layer />
+		<TextHaloWidth />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo blur"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-blur' }}
 	>
-		<TextHaloBlur bind:layer />
+		<TextHaloBlur />
 	</FieldControl>
 {/if}

--- a/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { getLayerIdContext } from '$lib/Layer.svelte';
 	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
@@ -13,13 +14,12 @@
 	import TextSize from '$lib/editor-controls/symbol/TextSize.svelte';
 	import type SpriteLoader from '$lib/sprite';
 	import FieldControl from '$lib/util/FieldControl.svelte';
-	import type { SymbolLayerSpecification } from 'maplibre-gl';
-	import { getContext } from 'svelte';
+	import type { LayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 
 	const map = getMapContext();
-	let layerId: string = getContext('layerId');
+	let layerId: string = getLayerIdContext();
 
-	let layer: SymbolLayerSpecification = $map.getStyle().layers.find((l) => {
+	let layer: SymbolLayerSpecification = $map.getStyle().layers.find((l: LayerSpecification) => {
 		l.id === layerId;
 	}) as SymbolLayerSpecification;
 	export let spriteLoader: SpriteLoader;

--- a/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { getMapContext } from '$lib/LegendPanel.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
 	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
@@ -11,12 +12,11 @@
 	import TextRotate from '$lib/editor-controls/symbol/TextRotate.svelte';
 	import TextSize from '$lib/editor-controls/symbol/TextSize.svelte';
 	import type SpriteLoader from '$lib/sprite';
-	import type { createMapStore } from '$lib/stores';
 	import FieldControl from '$lib/util/FieldControl.svelte';
 	import type { SymbolLayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
-	let map: ReturnType<typeof createMapStore> = getContext('map');
+	const map = getMapContext();
 	let layerId: string = getContext('layerId');
 
 	let layer: SymbolLayerSpecification = $map.getStyle().layers.find((l) => {

--- a/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
+++ b/packages/legend/src/lib/editor-panels/SymbolEditor.svelte
@@ -1,36 +1,39 @@
 <script lang="ts">
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import ColorControl from '$lib/editor-controls/ColorControl.svelte';
-	import type SpriteLoader from '$lib/sprite';
-	import IconHaloWidth from '$lib/editor-controls/symbol/IconHaloWidth.svelte';
-	import IconHaloBlur from '$lib/editor-controls/symbol/IconHaloBlur.svelte';
-	import IconSize from '$lib/editor-controls/symbol/IconSize.svelte';
-	import TextHaloWidth from '$lib/editor-controls/symbol/TextHaloWidth.svelte';
-	import TextHaloBlur from '$lib/editor-controls/symbol/TextHaloBlur.svelte';
-	import TextSize from '$lib/editor-controls/symbol/TextSize.svelte';
-	import TextRotate from '$lib/editor-controls/symbol/TextRotate.svelte';
-	import FieldControl from '$lib/util/FieldControl.svelte';
+	import Opacity from '$lib/editor-controls/Opacity.svelte';
 	import HeatmapGenerator from '$lib/editor-controls/heatmap/HeatmapGenerator.svelte';
+	import IconHaloBlur from '$lib/editor-controls/symbol/IconHaloBlur.svelte';
+	import IconHaloWidth from '$lib/editor-controls/symbol/IconHaloWidth.svelte';
 	import IconOverlap from '$lib/editor-controls/symbol/IconOverlap.svelte';
+	import IconSize from '$lib/editor-controls/symbol/IconSize.svelte';
+	import TextHaloBlur from '$lib/editor-controls/symbol/TextHaloBlur.svelte';
+	import TextHaloWidth from '$lib/editor-controls/symbol/TextHaloWidth.svelte';
+	import TextRotate from '$lib/editor-controls/symbol/TextRotate.svelte';
+	import TextSize from '$lib/editor-controls/symbol/TextSize.svelte';
+	import type SpriteLoader from '$lib/sprite';
+	import type { createMapStore } from '$lib/stores';
+	import FieldControl from '$lib/util/FieldControl.svelte';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { getContext } from 'svelte';
 
-	export let map: Map;
+	let map: ReturnType<typeof createMapStore> = getContext('map');
+
 	export let layer: LayerSpecification;
 	export let spriteLoader: SpriteLoader;
 
-	let iconImage = map.getLayoutProperty(layer.id, 'icon-image');
-	let textField = map.getLayoutProperty(layer.id, 'text-field');
+	let iconImage = $map.getLayoutProperty(layer.id, 'icon-image');
+	let textField = $map.getLayoutProperty(layer.id, 'text-field');
 </script>
 
 <FieldControl title="Heatmap" help={{ layerType: 'heatmap' }}>
-	<HeatmapGenerator bind:map bind:layer />
+	<HeatmapGenerator bind:layer />
 </FieldControl>
 
 <FieldControl
 	title="Opacity"
 	help={{ type: 'paint', layerType: 'symbol', property: 'icon-opacity' }}
 >
-	<Opacity bind:map bind:layer />
+	<Opacity bind:layer />
 </FieldControl>
 
 {#if iconImage}
@@ -38,14 +41,14 @@
 		title="Icon size"
 		help={{ type: 'layout', layerType: 'symbol', property: 'icon-size' }}
 	>
-		<IconSize bind:map bind:layer />
+		<IconSize bind:layer />
 	</FieldControl>
 
 	<FieldControl
 		title="Icon overlap"
 		help={{ type: 'layout', layerType: 'symbol', property: 'icon-overlap' }}
 	>
-		<IconOverlap bind:map bind:layer />
+		<IconOverlap bind:layer />
 	</FieldControl>
 
 	{#if spriteLoader?.isSdf(layer)}
@@ -53,28 +56,28 @@
 			title="Icon color"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-color' }}
 		>
-			<ColorControl bind:map bind:layer propertyName="icon-color" />
+			<ColorControl bind:layer propertyName="icon-color" />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo color"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-color' }}
 		>
-			<ColorControl bind:map bind:layer propertyName="icon-halo-color" />
+			<ColorControl bind:layer propertyName="icon-halo-color" />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo width"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-width' }}
 		>
-			<IconHaloWidth bind:map bind:layer />
+			<IconHaloWidth bind:layer />
 		</FieldControl>
 
 		<FieldControl
 			title="Icon halo blur"
 			help={{ type: 'paint', layerType: 'symbol', property: 'icon-halo-blur' }}
 		>
-			<IconHaloBlur bind:map bind:layer />
+			<IconHaloBlur bind:layer />
 		</FieldControl>
 	{/if}
 {/if}
@@ -84,41 +87,41 @@
 		title="Text size"
 		help={{ type: 'layout', layerType: 'symbol', property: 'text-size' }}
 	>
-		<TextSize bind:map bind:layer />
+		<TextSize bind:layer />
 	</FieldControl>
 
 	<FieldControl
 		title="Text color"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-color' }}
 	>
-		<ColorControl bind:map bind:layer propertyName="text-color" />
+		<ColorControl bind:layer propertyName="text-color" />
 	</FieldControl>
 
 	<FieldControl
 		title="Text rotate"
 		help={{ type: 'layout', layerType: 'symbol', property: 'text-rotate' }}
 	>
-		<TextRotate bind:map bind:layer />
+		<TextRotate bind:layer />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo color"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-color' }}
 	>
-		<ColorControl bind:map bind:layer propertyName="text-halo-color" />
+		<ColorControl bind:layer propertyName="text-halo-color" />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo width"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-width' }}
 	>
-		<TextHaloWidth bind:map bind:layer />
+		<TextHaloWidth bind:layer />
 	</FieldControl>
 
 	<FieldControl
 		title="Text halo blur"
 		help={{ type: 'paint', layerType: 'symbol', property: 'text-halo-blur' }}
 	>
-		<TextHaloBlur bind:map bind:layer />
+		<TextHaloBlur bind:layer />
 	</FieldControl>
 {/if}

--- a/packages/legend/src/lib/editor-panels/index.ts
+++ b/packages/legend/src/lib/editor-panels/index.ts
@@ -1,0 +1,23 @@
+import BackgroundEditor from './BackgroundEditor.svelte';
+import CircleEditor from './CircleEditor.svelte';
+import FillEditor from './FillEditor.svelte';
+import FillExtrusionEditor from './FillExtrusionEditor.svelte';
+import HeatmapEditor from './HeatmapEditor.svelte';
+import HillshadeEditor from './HillshadeEditor.svelte';
+import LineEditor from './LineEditor.svelte';
+import ManualEditor from './ManualEditor.svelte';
+import RasterEditor from './RasterEditor.svelte';
+import SymbolEditor from './SymbolEditor.svelte';
+
+export {
+	BackgroundEditor,
+	CircleEditor,
+	FillEditor,
+	FillExtrusionEditor,
+	HeatmapEditor,
+	HillshadeEditor,
+	LineEditor,
+	ManualEditor,
+	RasterEditor,
+	SymbolEditor
+};

--- a/packages/legend/src/lib/sprite.ts
+++ b/packages/legend/src/lib/sprite.ts
@@ -1,4 +1,4 @@
-import type { LayerSpecification } from 'maplibre-gl';
+import type { SymbolLayerSpecification } from 'maplibre-gl';
 
 export interface Sprite {
 	image: HTMLImageElement;
@@ -17,7 +17,7 @@ export interface spritePosition {
 class SpriteLoader {
 	private spriteUrl: string;
 
-	private sprite: Sprite;
+	private sprite?: Sprite = undefined;
 
 	constructor(url: string) {
 		this.spriteUrl = url;
@@ -61,15 +61,15 @@ class SpriteLoader {
 		return response.json();
 	}
 
-	getIconDataUrl(layer: LayerSpecification): string {
-		let dataUrl: string;
+	getIconDataUrl(layer: SymbolLayerSpecification): string {
+		let dataUrl = '';
 		if (layer.layout && layer.layout['icon-image']) {
 			let imgKey = layer.layout['icon-image'];
 			if (Array.isArray(imgKey)) {
-				imgKey = imgKey[imgKey.length - 1];
+				imgKey = imgKey[imgKey.length - 1] as string;
 			}
 			if (this.sprite?.json) {
-				let icon: spritePosition;
+				let icon: spritePosition | undefined = undefined;
 				Object.keys(this.sprite.json).forEach((id) => {
 					if (id === imgKey) {
 						icon = this.sprite.json[id];
@@ -89,7 +89,7 @@ class SpriteLoader {
 		el.width = sprite.width * dpi;
 		el.height = sprite.height * dpi;
 		const ctx = el.getContext('2d');
-		ctx.drawImage(
+		ctx?.drawImage(
 			img,
 			sprite.x * dpi,
 			sprite.y * dpi,
@@ -103,12 +103,12 @@ class SpriteLoader {
 		return el.toDataURL();
 	}
 
-	isSdf(layer: LayerSpecification) {
+	isSdf(layer: SymbolLayerSpecification) {
 		let isSdf = false;
 		if (layer.layout && layer.layout['icon-image']) {
 			let imgKey = layer.layout['icon-image'];
 			if (Array.isArray(imgKey)) {
-				imgKey = imgKey[imgKey.length - 1];
+				imgKey = imgKey[imgKey.length - 1] as string;
 			}
 			if (this.sprite?.json) {
 				let icon: spritePosition;

--- a/packages/legend/src/lib/stores/index.ts
+++ b/packages/legend/src/lib/stores/index.ts
@@ -1,7 +1,1 @@
-import type { LayerSpecification } from 'maplibre-gl';
-import { writable } from 'svelte/store';
-
-// map store for maplibre-gl object
-export const invisibleLayerMap = writable<{ [key: string]: LayerSpecification }>({});
-
 export * from './mapStore';

--- a/packages/legend/src/lib/stores/index.ts
+++ b/packages/legend/src/lib/stores/index.ts
@@ -3,3 +3,5 @@ import { writable } from 'svelte/store';
 
 // map store for maplibre-gl object
 export const invisibleLayerMap = writable<{ [key: string]: LayerSpecification }>({});
+
+export * from './mapStore';

--- a/packages/legend/src/lib/stores/mapStore.ts
+++ b/packages/legend/src/lib/stores/mapStore.ts
@@ -1,0 +1,115 @@
+import { writable } from 'svelte/store';
+import type { Map as MaplibreMap, StyleSetterOptions } from 'maplibre-gl';
+
+// map store for maplibre-gl object
+export const createMapStore = () => {
+	const { set, update, subscribe } = writable<MaplibreMap>(undefined);
+
+	/**
+	 * Update Maplibre's PaintProperty
+	 *
+	 * Note.
+	 * setPaintProperty does render map canvas with new given property value.
+	 * But in some cases, it does not actually update style.json object in Map instance.
+	 * Because of this problem of Maplibre, the function is going to update style.json directly and call `setStyle` function.
+	 *
+	 * @param layerId The ID of the layer to set the paint property in.
+	 * @param name The name of the paint property to set.
+	 * @param value The value of the paint property to set. Must be of a type appropriate for the property, as defined in the MapLibre Style Specification.
+	 * @param options Options object.
+	 */
+	const setPaintProperty = (
+		layerId: string,
+		name: string,
+		value: unknown,
+		options?: StyleSetterOptions
+	) => {
+		update((state) => {
+			if (state) {
+				state.setPaintProperty(layerId, name, value, options);
+
+				const style = state.getStyle();
+				const layer = style?.layers?.find((l) => l.id === layerId);
+				if (layer) {
+					if (!layer.paint) {
+						layer.paint = {};
+					}
+					if (value) {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						layer.paint[name] = value;
+					} else {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						if (layer.paint[name]) {
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore
+							delete layer.paint[name];
+						}
+					}
+					state.setStyle(style);
+				}
+			}
+
+			return state;
+		});
+	};
+
+	/**
+	 * Update Maplibre's LayoutProperty
+	 *
+	 * Note.
+	 * setLayoutProperty does render map canvas with new given property value.
+	 * But in some cases, it does not actually update style.json object in Map instance.
+	 * Because of this problem of Maplibre, the function is going to update style.json directly and call `setStyle` function.
+	 *
+	 * @param layerId The ID of the layer to set the paint property in.
+	 * @param name The name of the paint property to set.
+	 * @param value The value of the paint property to set. Must be of a type appropriate for the property, as defined in the MapLibre Style Specification.
+	 * @param options Options object.
+	 */
+	const setLayoutProperty = (
+		layerId: string,
+		name: string,
+		value: unknown,
+		options?: StyleSetterOptions
+	) => {
+		update((state) => {
+			if (state) {
+				state.setLayoutProperty(layerId, name, value, options);
+
+				const style = state.getStyle();
+				const layer = style?.layers?.find((l) => l.id === layerId);
+				if (layer) {
+					if (!layer.layout) {
+						layer.layout = {};
+					}
+					if (value) {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						layer.layout[name] = value;
+					} else {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						if (layer.layout[name]) {
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore
+							delete layer.layout[name];
+						}
+					}
+					state.setStyle(style);
+				}
+			}
+
+			return state;
+		});
+	};
+
+	return {
+		subscribe,
+		update,
+		set,
+		setPaintProperty,
+		setLayoutProperty
+	};
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^2.32.4
         version: 2.32.4(eslint@8.46.0)(svelte@4.1.1)
+      pmtiles:
+        specifier: ^2.10.0
+        version: 2.10.0
       prettier:
         specifier: ^3.0.0
         version: 3.0.0
@@ -591,10 +594,10 @@ importers:
         version: 4.1.1
       svelte-check:
         specifier: ^3.4.6
-        version: 3.4.6(postcss@8.4.28)(svelte@4.1.1)
+        version: 3.4.6(postcss@8.4.28)(sass@1.64.1)(svelte@4.1.1)
       svelte-preprocess:
         specifier: ^5.0.4
-        version: 5.0.4(postcss@8.4.28)(svelte@4.1.1)(typescript@5.1.6)
+        version: 5.0.4(postcss@8.4.28)(sass@1.64.1)(svelte@4.1.1)(typescript@5.1.6)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -603,7 +606,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^4.4.7
-        version: 4.4.7
+        version: 4.4.7(sass@1.64.1)
 
   packages/search:
     dependencies:
@@ -4983,33 +4986,6 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-check@3.4.6(postcss@8.4.28)(svelte@4.1.1):
-    resolution: {integrity: sha512-OBlY8866Zh1zHQTkBMPS6psPi7o2umTUyj6JWm4SacnIHXpWFm658pG32m3dKvKFL49V4ntAkfFHKo4ztH07og==}
-    hasBin: true
-    peerDependencies:
-      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.19
-      chokidar: 3.5.3
-      fast-glob: 3.3.1
-      import-fresh: 3.3.0
-      picocolors: 1.0.0
-      sade: 1.8.1
-      svelte: 4.1.1
-      svelte-preprocess: 5.0.4(postcss@8.4.28)(svelte@4.1.1)(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - '@babel/core'
-      - coffeescript
-      - less
-      - postcss
-      - postcss-load-config
-      - pug
-      - sass
-      - stylus
-      - sugarss
-    dev: true
-
   /svelte-copy@1.4.1(svelte@4.1.1):
     resolution: {integrity: sha512-ixNNlTfIQWYnQzE0pdMYVCS/2jzMhXm41jmtSvk8EK2Dh+B5sDFEz2xYYo4fVtwtK0dLW5M5ZH/Rs5Jah0r6dw==}
     peerDependencies:
@@ -5101,54 +5077,6 @@ packages:
       magic-string: 0.27.0
       postcss: 8.4.28
       sass: 1.64.1
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 4.1.1
-      typescript: 5.1.6
-    dev: true
-
-  /svelte-preprocess@5.0.4(postcss@8.4.28)(svelte@4.1.1)(typescript@5.1.6):
-    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
-    engines: {node: '>= 14.10.0'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.27.0
-      postcss: 8.4.28
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.1.1
@@ -5574,41 +5502,6 @@ packages:
       '@types/unist': 3.0.0
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
-    dev: true
-
-  /vite@4.4.7:
-    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.28
-      rollup: 3.28.1
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /vite@4.4.7(sass@1.64.1):


### PR DESCRIPTION
## Description

- refactor: use mapstore as context other than passing as prop
- refactor: add index.ts in editor-panels
- fix: add pmtiles library in example
- fixed typescript error
- refactor: set layerId in context, and to use it in all style editing components. Now layer prop was removed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

#### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others (refactoring)
<!-- ignore-task-list-end -->

#### Verify the followings

<!-- ignore-task-list-start -->

- [x] Have you referenced related issues in the repo if they are present ([issues](https://github.com/watergis/svelte-maplibre-components/issues))?
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [x] Updated documentation in the packages you modified in [sites/svelte.water-gis.com](sites/svelte.water-gis.com) folder and `README.md` of the package.
<!-- ignore-task-list-end -->

#### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


